### PR TITLE
Refresh Operator Hub layout and styling

### DIFF
--- a/isnack/isnack/page/operator_hub/operator_hub.css
+++ b/isnack/isnack/page/operator_hub/operator_hub.css
@@ -12,6 +12,11 @@
 
   --teal:#15b79e;       /* primary accent (teal) */
   --teal-d:#109487;
+  --blue:#3b82f6;
+  --blue-soft:#e8f1ff;
+  --teal-soft:#e7fbf7;
+  --amber-soft:#fff3d6;
+  --red-soft:#ffe7e7;
   --red:#ef4444;
   --amber:#f59e0b;
   --gray:#9aa6b2;
@@ -53,8 +58,8 @@
   background:var(--panel);
   border:1px solid var(--line);
   border-radius:10px;
-  padding:8px 12px;
-  box-shadow:var(--shadow-sm);
+  padding:6px 10px;
+  box-shadow:0 4px 10px rgba(17,24,39,.06);
 }
 .op-teal .op-toolbar .label{ color:var(--muted); font-weight:600; }
 .op-teal .op-toolbar .vr{ width:1px; height:18px; background:var(--line); margin:0 14px; }
@@ -72,13 +77,13 @@
 /* Header time: larger & spaced */
 .op-teal .op-toolbar #op-time{
   margin-left:.75rem;
-  padding:.25rem .7rem;
+  padding:.2rem .6rem;
   border:1px solid var(--line);
   border-radius:8px;
   background:var(--panel-2);
   color:var(--ink);
   font-weight:700;
-  font-size:1.25rem;
+  font-size:1.1rem;
   line-height:1.1;
   letter-spacing:.3px;
   font-variant-numeric: tabular-nums lining-nums;
@@ -106,14 +111,14 @@
    ===================================== */
 /* Reduce excessive padding in card headers and bodies */
 .op-teal .mes-operator .card-header{
-  padding:0.5rem 1rem !important;
+  padding:0.4rem 0.8rem !important;
 }
 .op-teal .mes-operator .card-body{
-  padding:0.75rem 1rem !important;
+  padding:0.6rem 0.8rem !important;
 }
 /* Reduce margin between sections */
 .op-teal .mes-operator > .card{
-  margin-bottom:0.75rem !important;
+  margin-bottom:0.5rem !important;
 }
 
 /* Work Order grid: reserve space for sticky bottom toolbar */
@@ -134,14 +139,15 @@
   background:var(--panel);
   border:1px solid var(--line);
   border-radius:12px;
-  box-shadow:var(--shadow);
-  padding:12px 16px;
+  box-shadow:0 6px 16px rgba(17,24,39,.06);
+  padding:10px 12px;
 }
 .op-teal .list-group-item{
   background:var(--panel);
   border:1px solid var(--line);
   border-radius:12px;
-  margin-bottom:10px;
+  margin-bottom:8px;
+  padding:.6rem .8rem;
   color:var(--ink);
   transition:transform .08s ease, box-shadow .12s ease, border-color .12s ease;
 }
@@ -158,6 +164,31 @@
   font-size:.72rem; text-transform:uppercase;
   background:#f0f3f6; border:1px solid var(--line);
   color:#334155;
+}
+
+/* Badges in toolbar */
+.op-teal .op-badge{
+  border-radius:999px;
+  font-weight:700;
+  padding:.2rem .55rem;
+  border:1px solid var(--line);
+  background:var(--panel-2);
+  color:var(--ink);
+}
+.op-teal .op-badge-status{ background:var(--teal-soft); border-color:#b8f1e6; color:#0f766e; }
+.op-teal .op-badge-shift{ background:var(--blue-soft); border-color:#cfe0ff; color:#1d4ed8; }
+
+/* Panel accents */
+.op-teal .op-panel{
+  position:relative;
+  border-left:4px solid transparent;
+}
+.op-teal .op-panel-primary{ border-left-color:var(--teal); }
+.op-teal .op-panel-info{ border-left-color:var(--blue); }
+.op-teal .op-panel-neutral{ border-left-color:var(--line-strong); }
+
+.op-teal .op-wo-banner{
+  background:linear-gradient(120deg, var(--teal-soft) 0%, #ffffff 55%);
 }
 .op-teal .chip-fg{ background:#e6fbf7; border-color:#bdf3ea; color:#0f766e; }
 .op-teal .chip-sf{ background:#eef2ff; border-color:#dfe6ff; color:#3730a3; }
@@ -200,6 +231,22 @@
   background:#fff5f5!important; border-color:#fca5a5!important; color:#7f1d1d!important;
 }
 
+/* Operator-meaningful colors for action groups */
+.op-teal #btn-start{
+  background:var(--teal)!important; border-color:var(--teal-d)!important; color:#053b37!important;
+}
+.op-teal #btn-pause{
+  background:var(--amber)!important; border-color:#d97706!important; color:#3b2400!important;
+}
+.op-teal #btn-stop{
+  background:var(--red)!important; border-color:#dc2626!important; color:#fff5f5!important;
+}
+.op-teal #btn-load{ background:#0ea5e9!important; border-color:#0284c7!important; color:#07344a!important; }
+.op-teal #btn-request{ background:#f59e0b!important; border-color:#d97706!important; color:#3b2400!important; }
+.op-teal #btn-return{ background:#f3f4f6!important; border-color:#d1d5db!important; color:#111827!important; }
+.op-teal #btn-label{ background:#22c55e!important; border-color:#16a34a!important; color:#052e16!important; }
+.op-teal #btn-close{ background:#6b7280!important; border-color:#4b5563!important; color:#f8fafc!important; }
+
 /* =====================================
    Sticky Bottom Action Bar
    ===================================== */
@@ -223,9 +270,9 @@
 /* keep content clear of the fixed bar */
 .op-teal .mes-operator{
   padding-bottom:180px; /* height of action bar + status bar + extra margin */
-  padding-left:0.75rem !important;  /* reduce side padding */
-  padding-right:0.75rem !important; /* reduce side padding */
-  padding-top:0.75rem !important;   /* reduce top padding */
+  padding-left:0.6rem !important;  /* reduce side padding */
+  padding-right:0.6rem !important; /* reduce side padding */
+  padding-top:0.6rem !important;   /* reduce top padding */
 }
 
 /* container behaviours */
@@ -265,22 +312,22 @@
 
 /* compact tile buttons */
 .op-teal .tile-btn{
-  min-height:78px;
-  padding:.65rem .8rem;
-  font-size:.95rem;
+  min-height:70px;
+  padding:.55rem .7rem;
+  font-size:.92rem;
   border-radius:10px;
   letter-spacing:.12px;
   font-weight:700;
   white-space:normal;   /* allow wrap */
   line-height:1.2;
-  min-width:140px;
+  min-width:130px;
   text-align:center;
 }
 
 /* Double-width for run controls (Start / Pause / Stop) */
 .op-teal .op-bottom .bar-group .tile-btn.wide-2x{
   flex:2 1 0;
-  min-width:220px;
+  min-width:200px;
 }
 
 /* Fallback: ensure spacing if buttons are not wrapped in a .bar-group */

--- a/isnack/public/page/operator_hub/operator_hub.html
+++ b/isnack/public/page/operator_hub/operator_hub.html
@@ -1,8 +1,8 @@
 <!-- Operator Hub — Single-Screen Layout (Bootstrap 5) -->
-<div class="mes-operator p-3 p-md-4">
+<div class="mes-operator p-2 p-md-3">
 
   <!-- Header toolbar: Operator / Line / Shift + actions -->
-  <div class="card shadow-sm border-0 mb-3">
+  <div class="card shadow-sm border-0 mb-2">
     <div class="card-body">
       <div id="op-toolbar" class="op-toolbar d-flex align-items-center justify-content-between">
         <div class="d-flex flex-wrap align-items-center gap-3">
@@ -19,10 +19,11 @@
           <span class="vr"></span>
 
           <span class="label">Shift:</span>
-          <span id="shift-label">—</span>
+          <span id="shift-label" class="badge op-badge op-badge-shift">—</span>
         </div>
 
         <div class="d-flex flex-wrap align-items-center gap-2">
+          <span id="scan-status" class="badge op-badge op-badge-status">Ready</span>
           <button id="kiosk-clear-emp" class="btn btn-sm btn-outline-danger">Clear</button>
           <button id="kiosk-fullscreen" class="btn btn-sm btn-outline-primary">Full Screen</button>
           <button id="kiosk-toggle-chrome" class="btn btn-sm btn-outline-secondary">Hide Header</button>
@@ -32,46 +33,52 @@
     </div>
   </div>
 
-  <!-- Current Work Order Panel -->
-  <div class="card shadow-sm border-0 mb-3">
-    <div class="card-header bg-white border-0 pt-3 pb-0">
-      <div class="h6 mb-0">Current Work Order</div>
+  <div class="row g-3">
+    <!-- Current Work Order Panel -->
+    <div class="col-lg-5">
+      <div class="card shadow-sm border-0 mb-2 op-panel op-panel-primary">
+        <div class="card-header bg-white border-0 pt-2 pb-0">
+          <div class="h6 mb-0">Current Work Order</div>
+        </div>
+        <div class="card-body op-wo-banner" id="wo-banner">
+          <div class="text-muted">Select a Work Order…</div>
+        </div>
+      </div>
     </div>
-    <div class="card-body" id="wo-banner">
-      <div class="text-muted">Select a Work Order…</div>
-    </div>
-  </div>
 
-  <!-- Materials panel -->
-  <div class="card shadow-sm border-0 mb-3">
-    <div class="card-header bg-white border-0 pt-3 pb-0 d-flex justify-content-between align-items-center">
-      <div class="h6 mb-0">Materials for WO: <span id="mat-wo-label">—</span></div>
-    </div>
-    <div class="card-body">
-      <div id="mat-empty" class="text-muted">Select a Work Order to load materials.</div>
+    <!-- Materials panel -->
+    <div class="col-lg-7">
+      <div class="card shadow-sm border-0 mb-2 op-panel op-panel-info">
+        <div class="card-header bg-white border-0 pt-2 pb-0 d-flex justify-content-between align-items-center">
+          <div class="h6 mb-0">Materials for WO: <span id="mat-wo-label">—</span></div>
+        </div>
+        <div class="card-body">
+          <div id="mat-empty" class="text-muted">Select a Work Order to load materials.</div>
 
-      <div id="mat-content" class="d-none">
-        <div class="row g-3">
-          <div class="col-lg-8">
-            <div class="table-responsive">
-              <table class="table table-sm align-middle">
-                <thead>
-                  <tr>
-                    <th>Item</th>
-                    <th style="min-width:180px">Name</th>
-                    <th class="text-end">UoM</th>
-                    <th class="text-end">Required</th>
-                    <th class="text-end">Issued</th>
-                    <th class="text-end">Remaining</th>
-                  </tr>
-                </thead>
-                <tbody id="mat-req-tbody"></tbody>
-              </table>
+          <div id="mat-content" class="d-none">
+            <div class="row g-3">
+              <div class="col-lg-8">
+                <div class="table-responsive">
+                  <table class="table table-sm align-middle">
+                    <thead>
+                      <tr>
+                        <th>Item</th>
+                        <th style="min-width:180px">Name</th>
+                        <th class="text-end">UoM</th>
+                        <th class="text-end">Required</th>
+                        <th class="text-end">Issued</th>
+                        <th class="text-end">Remaining</th>
+                      </tr>
+                    </thead>
+                    <tbody id="mat-req-tbody"></tbody>
+                  </table>
+                </div>
+              </div>
+              <div class="col-lg-4">
+                <div class="h6">Recent Issues/Transfers</div>
+                <ul class="list-group" id="mat-scans"></ul>
+              </div>
             </div>
-          </div>
-          <div class="col-lg-4">
-            <div class="h6">Recent Issues/Transfers</div>
-            <ul class="list-group" id="mat-scans"></ul>
           </div>
         </div>
       </div>
@@ -81,12 +88,9 @@
   <!-- Assigned Work Orders -->
   <div class="mb-2 d-flex align-items-center justify-content-between">
     <div class="h6 mb-0">Assigned Work Orders</div>
-    <div class="small text-muted">
-      <span id="scan-status" class="badge bg-light text-muted">Ready</span>
-    </div>
   </div>
 
-  <div class="card shadow-sm border-0 mb-4">
+  <div class="card shadow-sm border-0 mb-3 op-panel op-panel-neutral">
     <div class="list-group list-group-flush" id="wo-grid">
       <!-- JS renders rows here -->
     </div>


### PR DESCRIPTION
### Motivation
- Improve operator-focused UI by tightening spacing and reducing visual clutter to fit more information on a single screen.  
- Surface important runtime state (scan status, shift) with prominent badges for faster recognition.  
- Place `Current Work Order` and `Materials` side-by-side on wide screens to reduce context switching.  
- Provide clearer, semantic action button colors to communicate intent for Start/Pause/Stop and material actions.

### Description
- Updated `isnack/public/page/operator_hub/operator_hub.html` to reduce top-level paddings, add a `scan-status` badge, make the `shift-label` a styled badge, and reorganize the WO/Materials sections into a two-column `.row` (`col-lg-5` / `col-lg-7`) with panel accent classes.  
- Enhanced `isnack/isnack/page/operator_hub/operator_hub.css` with new variables and styles for badges (`.op-badge`, `.op-badge-status`, `.op-badge-shift`), panel accents (`.op-panel*`), a banner gradient (`.op-wo-banner`), and tightened paddings/margins across headers, cards, and list items.  
- Adjusted sticky bottom action bar visuals and button sizes, and added operator-meaningful colors for action buttons (`#btn-start`, `#btn-pause`, `#btn-stop`, `#btn-load`, etc.).  
- Small layout/spacing tweaks: reduced card margins, smaller toolbar padding, compact `tile-btn` sizing, and added list item padding for better touch targets.

### Testing
- A Playwright script navigated to `http://127.0.0.1:8000/operator-hub` and produced a full-page screenshot at `artifacts/operator-hub.png`, which completed successfully.  
- Verified repository changes with `git status` and committed the updates as `Refresh Operator Hub layout and styling`.  
- No automated unit or integration tests were added or run for these UI-only changes.  
- Manual visual verification (screenshot) was used to confirm layout and style adjustments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f5496e6c8325923d868ac033fcc5)