### PR TITLE
Add allocation status visibility and gating in Operator Hub

### DIFF
--- a/isnack/isnack/page/operator_hub/operator_hub.css
+++ b/isnack/isnack/page/operator_hub/operator_hub.css
@@ -196,6 +196,9 @@
 .op-teal .chip-running{ background:#e6fbf7; color:#0f766e; border-color:#bdf3ea; }
 .op-teal .chip-paused{ background:#fff7e6; color:#92400e; border-color:#fde68a; }
 .op-teal .chip-stopped{ background:#fee2e2; color:#991b1b; border-color:#fecaca; }
+.op-teal .chip-allocated{ background:#ecfdf5; color:#047857; border-color:#a7f3d0; }
+.op-teal .chip-partial{ background:#fef3c7; color:#92400e; border-color:#fde68a; }
+.op-teal .chip-not-allocated{ background:#f3f4f6; color:#6b7280; border-color:#e5e7eb; }
 
 /* Scan input */
 .op-teal #scan{


### PR DESCRIPTION
### Motivation
- Surface storekeeper allocation state for Work Orders in the Operator Hub so operators can see whether materials are staged. 
- Prevent operators from starting/pausing/stopping/resuming WOs that are not fully allocated to avoid running without materials. 
- Provide a visual indicator (chip) in the queue for `Staged` / `Partial` / `Not Staged` statuses. 
- Keep operator UX consistent by disabling actions until allocation is complete.

### Description
- Import `_stage_status` from `isnack.page.storekeeper_hub.storekeeper_hub` and add `stage_status` to the Work Order payload in `isnack/api/mes_ops.py` via `get_line_queue`.
- Add a server-side gating check in `set_work_order_state` (in `isnack/api/mes_ops.py`) that throws if the WO is not `Staged` for actions `start`, `pause`, `stop`, `resume`, or `reopen`.
- Update the Operator Hub client (`isnack/page/operator_hub/operator_hub.js`) to track `current_stage_status`, render allocation chips in the WO grid, and disable action buttons unless `state.current_stage_status === 'Staged'`.
- Add CSS styles for the new allocation chips in `isnack/page/operator_hub/operator_hub.css` to show `Allocated`, `Partly Allocated`, and `Not Allocated` states.

### Testing
- Attempted automated UI validation with a Playwright screenshot script to capture the Operator Hub state, but the Chromium run crashed (Playwright/Chromium SIGSEGV) and the screenshot did not complete (failed).
- No other automated tests (unit/integration) were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fc3993ec83259f52a80414530096)