### PR TITLE
Fix storekeeper hub import and enforce allocation gating in Operator Hub

### DIFF
--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -7,6 +7,9 @@ from typing import Optional, Tuple
 
 import frappe
 from frappe import _
+from isnack.isnack.page.storekeeper_hub.storekeeper_hub import (
+    _stage_status as _storekeeper_stage_status,
+)
 
 # ============================================================
 # Factory Settings helpers (Single doctype)
@@ -427,6 +430,7 @@ def get_line_queue(line: Optional[str] = None):
                 "line": wo_line,
                 "for_quantity": wo.qty,
                 "status": wo.status,
+                "stage_status": _storekeeper_stage_status(wo.name),
                 "production_item": wo.production_item,
                 "item_name": wo.item_name,
                 "type": "FG" if _is_fg(wo.production_item) else "SF",
@@ -585,6 +589,9 @@ def set_work_order_state(
     now = frappe.utils.now_datetime()
     action_lc = (action or "").strip().lower()
     updates: dict = {}
+    stage_status = _storekeeper_stage_status(work_order)
+    if stage_status != "Staged" and action_lc in ("start", "pause", "stop", "resume", "reopen"):
+        frappe.throw(_("Work Order must be fully allocated before this action."))
 
     if action_lc == "start":
         updates["status"] = "In Process"

--- a/isnack/isnack/page/operator_hub/operator_hub.css
+++ b/isnack/isnack/page/operator_hub/operator_hub.css
@@ -196,6 +196,9 @@
 .op-teal .chip-running{ background:#e6fbf7; color:#0f766e; border-color:#bdf3ea; }
 .op-teal .chip-paused{ background:#fff7e6; color:#92400e; border-color:#fde68a; }
 .op-teal .chip-stopped{ background:#fee2e2; color:#991b1b; border-color:#fecaca; }
+.op-teal .chip-allocated{ background:#ecfdf5; color:#047857; border-color:#a7f3d0; }
+.op-teal .chip-partial{ background:#fef3c7; color:#92400e; border-color:#fde68a; }
+.op-teal .chip-not-allocated{ background:#f3f4f6; color:#6b7280; border-color:#e5e7eb; }
 
 /* Scan input */
 .op-teal #scan{


### PR DESCRIPTION
### Motivation
- Surface Storekeeper allocation state in the Operator Hub so operators can see whether materials are staged for each Work Order.
- Prevent operators from starting/pausing/stopping/resuming/reopening WOs that are not fully allocated to avoid running without materials.
- Provide a visual indicator (chip) in the queue for `Staged` / `Partial` / `Not Staged` allocation statuses.
- Resolve a runtime import error that caused page refreshes to fail due to an incorrect module path for the Storekeeper helper.

### Description
- Fix the import path for the Storekeeper Hub helper in `mes_ops.py` by importing `_stage_status` from `isnack.isnack.page.storekeeper_hub.storekeeper_hub` to avoid the `No module named 'isnack.page'` error.
- Add `stage_status` to the Work Order payload in `get_line_queue` and enforce server-side gating in `set_work_order_state` to throw if the WO is not `Staged` for actions `start`, `pause`, `stop`, `resume`, or `reopen`.
- Transfer staged materials to WIP when starting a Work Order by invoking `transfer_staged_to_wip` and log/notify on success or warning on failure.
- Update the Operator Hub client (`operator_hub.js`) to track `current_stage_status`, render allocation chips in the WO grid, and disable action buttons unless `state.current_stage_status === 'Staged'`, plus add CSS styles for the new chips in `operator_hub.css`.

### Testing
- Attempted a Playwright UI screenshot to validate the Operator Hub, but the Chromium run crashed (SIGSEGV) and the screenshot run failed.
- No unit or integration automated tests were executed for the import fix or the allocation gating change.
- The import path change was committed and the runtime import error should be resolved, but no automated verification was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fc3993ec83259f52a80414530096)