### PR TITLE
Fix storekeeper hub import path in mes_ops

### DIFF
--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -7,7 +7,9 @@ from typing import Optional, Tuple
 
 import frappe
 from frappe import _
-from isnack.page.storekeeper_hub.storekeeper_hub import _stage_status as _storekeeper_stage_status
+from isnack.isnack.page.storekeeper_hub.storekeeper_hub import (
+    _stage_status as _storekeeper_stage_status,
+)
 
 # ============================================================
 # Factory Settings helpers (Single doctype)


### PR DESCRIPTION
### Motivation
- The Operator Hub was failing with a missing module error for `isnack.page` (e.g. "No module named 'isnack.page'"), indicating the import path did not match the package layout.
- The repository contains a nested `isnack/isnack` package layout, so the runtime import needed to reference the inner package.

### Description
- Updated the import in `isnack/api/mes_ops.py` to use `from isnack.isnack.page.storekeeper_hub.storekeeper_hub import _stage_status as _storekeeper_stage_status`.
- Reformatted the import to a multiline form for clarity and consistency.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69610be59f708325b59e299c643d5129)