### PR TITLE
Refine operator hub button grouping and color palettes

### DIFF
--- a/isnack/isnack/page/operator_hub/operator_hub.css
+++ b/isnack/isnack/page/operator_hub/operator_hub.css
@@ -324,6 +324,83 @@
   text-align:center;
 }
 
+/* =========================
+   Button palettes by group
+   ========================= */
+.op-teal .op-bottom .tile-btn{
+  border:1px solid transparent;
+  box-shadow:0 6px 14px rgba(15,23,42,.08);
+  transition:transform .12s ease, box-shadow .12s ease, background-color .12s ease;
+}
+
+.op-teal .op-bottom .tile-btn:enabled:hover{
+  transform:translateY(-1px);
+  box-shadow:0 10px 18px rgba(15,23,42,.14);
+}
+
+.op-teal .op-bottom .tile-btn:disabled{
+  opacity:.55;
+  box-shadow:none;
+}
+
+/* Group 1: Run controls (go / stop) */
+.op-teal .op-bottom .op-btn-run-start{
+  background:#16a34a;
+  border-color:#15803d;
+  color:#ffffff;
+}
+
+.op-teal .op-bottom .op-btn-run-toggle.btn-warning{
+  background:#f59e0b;
+  border-color:#d97706;
+  color:#1f2937;
+}
+
+.op-teal .op-bottom .op-btn-run-toggle.btn-success{
+  background:#22c55e;
+  border-color:#16a34a;
+  color:#ffffff;
+}
+
+/* Group 2: Materials */
+.op-teal .op-bottom .op-btn-material{
+  background:#2563eb;
+  border-color:#1d4ed8;
+  color:#ffffff;
+}
+
+.op-teal .op-bottom .op-btn-material-strong{
+  background:#1e40af;
+  border-color:#1e3a8a;
+  color:#ffffff;
+}
+
+.op-teal .op-bottom .op-btn-material-outline{
+  background:#eff6ff;
+  border-color:#93c5fd;
+  color:#1e3a8a;
+}
+
+/* Group 3: Labels */
+.op-teal .op-bottom .op-btn-label{
+  background:#7c3aed;
+  border-color:#6d28d9;
+  color:#ffffff;
+}
+
+.op-teal .op-bottom .op-btn-label-outline{
+  background:#f5f3ff;
+  border-color:#c4b5fd;
+  color:#5b21b6;
+}
+
+/* Group 4: Close / End */
+.op-teal .op-bottom .op-btn-close{
+  background:#64748b;
+  border-color:#475569;
+  color:#ffffff;
+}
+
 /* Double-width for run controls (Start / Pause / Stop) */
 .op-teal .op-bottom .bar-group .tile-btn.wide-2x{
   flex:2 1 0;

--- a/isnack/public/page/operator_hub/operator_hub.html
+++ b/isnack/public/page/operator_hub/operator_hub.html
@@ -109,23 +109,33 @@
       <div class="op-bottom d-flex flex-nowrap align-items-stretch" style="gap:1rem">
 
         <!-- Group 1: Run controls -->
-        <div class="tile-group">
-          <button id="btn-start" class="btn btn-lg btn-primary tile-btn">Start</button>
-          <button id="btn-pause" class="btn btn-lg btn-warning tile-btn">Pause</button>
+        <div class="bar-group" aria-label="Run controls">
+          <button id="btn-start" class="btn btn-lg tile-btn op-btn-run-start">Start</button>
+          <button id="btn-pause" class="btn btn-lg btn-warning tile-btn op-btn-run-toggle">Pause</button>
         </div>
+
+        <div class="bar-sep" aria-hidden="true"></div>
 
         <!-- Group 2: Materials -->
-        <div class="tile-group">
-          <button id="btn-load"    class="btn btn-lg btn-info tile-btn">Load Materials</button>
-          <button id="btn-request" class="btn btn-lg btn-warning tile-btn">Request More Material</button>
-          <button id="btn-return"  class="btn btn-lg btn-outline-secondary tile-btn">Return Materials</button>
+        <div class="bar-group" aria-label="Materials">
+          <button id="btn-load" class="btn btn-lg tile-btn op-btn-material">Load Materials</button>
+          <button id="btn-request" class="btn btn-lg tile-btn op-btn-material-strong">Request More Material</button>
+          <button id="btn-return" class="btn btn-lg tile-btn op-btn-material-outline">Return Materials</button>
         </div>
 
-        <!-- Group 3: Output -->
-        <div class="tile-group">
-          <button id="btn-label" class="btn btn-lg btn-success tile-btn" disabled>Print Label</button>
-          <button id="btn-label-history" class="btn btn-lg btn-outline-success tile-btn" disabled>Label History</button>
-          <button id="btn-close" class="btn btn-lg btn-secondary tile-btn">Close / End</button>
+        <div class="bar-sep" aria-hidden="true"></div>
+
+        <!-- Group 3: Labels -->
+        <div class="bar-group" aria-label="Labels">
+          <button id="btn-label" class="btn btn-lg tile-btn op-btn-label" disabled>Print Label</button>
+          <button id="btn-label-history" class="btn btn-lg tile-btn op-btn-label-outline" disabled>Label History</button>
+        </div>
+
+        <div class="bar-sep" aria-hidden="true"></div>
+
+        <!-- Group 4: Close / End -->
+        <div class="bar-group" aria-label="Close or End">
+          <button id="btn-close" class="btn btn-lg tile-btn op-btn-close">Close / End</button>
         </div>
 
       </div>


### PR DESCRIPTION
### Motivation

- Improve the meaning and aesthetics of the operator hub action buttons by assigning cohesive, purposeful colors to related actions.  
- Visually segregate action types into four groups: run controls, materials, labels, and close/end for clearer operator workflow.  
- Make buttons feel more tactile with hover and disabled states to improve affordance.  
- Add accessible group labeling to aid screen readers and clarify structure.

### Description

- Reorganized the action bar HTML to use grouped containers and separators and added ARIA labels, replacing older `tile-group` blocks with `bar-group` and `bar-sep` in `public/page/operator_hub/operator_hub.html`.  
- Introduced semantic per-group button classes (`op-btn-run-start`, `op-btn-run-toggle`, `op-btn-material*`, `op-btn-label*`, `op-btn-close`) and removed ad-hoc Bootstrap color reliance in the action bar.  
- Added a new palette and interaction styles (hover, disabled, shadows, transitions) for grouped buttons in `isnack/page/operator_hub/operator_hub.css`, including special handling for the `Pause/Resume` toggle when it switches `btn-warning`/`btn-success`.  
- Kept layout rules for sizing and spacing; groups are visually separated and retain double-width support for run controls where needed.

### Testing

- Generated a visual snapshot of the updated Operator Hub using a Playwright script that loaded `http://127.0.0.1:8000/app/operator-hub` and saved `artifacts/operator-hub-buttons.png`, which completed successfully.  
- No unit or integration tests were modified or executed as part of this change.  
- Basic repository checks (`git status`, file diffs) were performed and the changes were committed locally.  
- Manual inspection of the updated HTML/CSS was performed via the captured screenshot to validate grouping and styling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964caec57a48325a51257d83fbd3a9c)