### PR TITLE
Include Customs Export Declaration No in Traceability Report headers

### DIFF
--- a/isnack/isnack/report/customs_export_traceability_report/customs_export_traceability_report.py
+++ b/isnack/isnack/report/customs_export_traceability_report/customs_export_traceability_report.py
@@ -698,6 +698,7 @@ def _fetch_si_header_details(si_names):
 			po_no,
 			territory,
 			remarks,
+			custom_customs_document_no,
 			customer_address,
 			shipping_address_name,
 			address_display,
@@ -850,6 +851,7 @@ def get_print_html(filters):
 			"company": _v(first.get("company")),
 			"po_no": _v(si_extra.get("po_no")),
 			"territory": _v(si_extra.get("territory")),
+			"customs_export_declaration_no": _v(si_extra.get("custom_customs_document_no")),
 			"remarks": _v(si_extra.get("remarks")),
 			"customer_address": _v(si_extra.get("address_display") or si_extra.get("customer_address")),
 			"company_address": _v(si_extra.get("company_address_display")),
@@ -1027,16 +1029,16 @@ def get_export_excel(filters):
 		po_no = si_extra.get("po_no") or ""
 		territory = si_extra.get("territory") or ""
 		remarks = si_extra.get("remarks") or ""
-		customs_export_document_no = si_extra.get("customs_export_document_no") or ""
+		customs_export_declaration_no = si_extra.get("custom_customs_document_no") or ""
 
-		if po_no or territory:
+		if po_no or territory or customs_export_declaration_no:
 			extra_parts = []
 			if po_no:
 				extra_parts.append(f"PO Ref: {po_no}")
 			if territory:
 				extra_parts.append(f"Territory: {territory}")
-			if customs_export_document_no:
-				extra_parts.append(f"Customs Export Document No: {customs_export_document_no}")				
+			if customs_export_declaration_no:
+				extra_parts.append(f"Customs Export Declaration No: {customs_export_declaration_no}")
 			_write_merged_row(
 				" | ".join(extra_parts),
 				font=_normal_font(size=9),

--- a/isnack/isnack/report/customs_export_traceability_report/customs_export_traceability_report_print.html
+++ b/isnack/isnack/report/customs_export_traceability_report/customs_export_traceability_report_print.html
@@ -260,6 +260,12 @@
       <span class="field-value">{{ invoice.territory }}</span>
     </div>
     {% endif %}
+    {% if invoice.customs_export_declaration_no %}
+    <div class="field-pair">
+      <span class="field-label">Customs Export Declaration No</span>
+      <span class="field-value">{{ invoice.customs_export_declaration_no }}</span>
+    </div>
+    {% endif %}
     {% if invoice.company_address %}
     <div class="field-pair">
       <span class="field-label">Company Address</span>


### PR DESCRIPTION
### Motivation
- The report should show the Sales Invoice custom field `Customs Export Declaration No` in the invoice header for both print and Excel outputs because this was partially implemented but not finished.

### Description
- Added `custom_customs_document_no` to the `SELECT` in `_fetch_si_header_details` so the Sales Invoice custom field is retrieved in bulk.
- Exposed the value in the print/export context as `customs_export_declaration_no` (wired into the invoices context built in `get_print_html`).
- Updated the print template `customs_export_traceability_report_print.html` to render `Customs Export Declaration No` in the invoice header block when present.
- Updated the Excel export logic in `get_export_excel` to read `custom_customs_document_no` and include `Customs Export Declaration No` in the invoice extra detail line.

### Testing
- Ran `python -m py_compile isnack/isnack/report/customs_export_traceability_report/customs_export_traceability_report.py`, which completed without syntax errors.
- Verified the template and export code were updated to reference the new context key and field name (static code inspection).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f306de2883258e6bfef28bb2f050)