### PR TITLE
Add Work Order context to Manual Load dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,17 +820,19 @@ Both hubs integrate seamlessly with ERPNext's native manufacturing, inventory, a
 
 1. Click **Manual Load** button
 2. Select **Item Code** from the dropdown (description auto-populates)
-3. Select **Batch No** — filtered to batches available in the Staging Warehouse for the current line
-4. **Available Qty** auto-populates with the quantity in the Staging Warehouse for the selected batch
-5. Enter **Qty** to consume (cannot exceed Available Qty)
-6. Click **Add** to add the item to the consumption list
-7. Repeat steps 2–6 for additional items
-8. Click **Post Consumption** to submit
+3. **Required Qty** and **Remaining Qty** auto-populate from the current Work Order's BOM and prior consumption
+4. Select **Batch No** — filtered to batches available in the WIP Warehouse for the current line
+5. **Available Qty in WIP** auto-populates with the quantity in the WIP Warehouse for the selected batch (or item-level when no batch is chosen)
+6. Enter **Qty** to consume (cannot exceed Available Qty in WIP when a batch is selected; Remaining Qty is shown for guidance only)
+7. Click **Add** to add the item to the consumption list
+8. Repeat steps 2–7 for additional items
+9. Click **Post Consumption** to submit
 
 **Features:**
 - Works without barcode scanner
-- Batch filter shows only batches with available stock in the Staging Warehouse
-- Qty validation prevents over-entry at dialog level
+- Batch filter shows only batches with available stock in the WIP Warehouse
+- Required / Remaining qty show WO-specific context alongside warehouse availability
+- Qty validation prevents over-entry against batch availability at dialog level
 - Over-consumption threshold check (same as scan-based Load)
 - Creates the same Stock Entry type as scanner-based Load
 

--- a/docs/production-plan-to-operator-hub-guide.md
+++ b/docs/production-plan-to-operator-hub-guide.md
@@ -287,9 +287,10 @@ Click **Load Materials**. The scan field is automatically focused. Scan the barc
 Click **Manual Load** if you do not have a scanner:
 1. Select Item Code (e.g., `Corn Starch`).
 2. Select Batch No if applicable.
-3. Enter Qty (e.g., `50`).
-4. Click **Add**, then repeat for each item.
-5. Click **Post Consumption** to save all rows at once.
+3. Review **Required Qty**, **Remaining Qty** and **Available Qty in WIP** to decide how much to load.
+4. Enter Qty (e.g., `50`).
+5. Click **Add**, then repeat for each item.
+6. Click **Post Consumption** to save all rows at once.
 
 The **Materials** panel updates in real time:
 

--- a/docs/storekeeper-operator-hub-flow.md
+++ b/docs/storekeeper-operator-hub-flow.md
@@ -233,11 +233,13 @@ Click **Manual Load** for situations without a barcode scanner:
 1. Select an **Item Code** (filtered to items from the WO's BOM that have stock in the WIP warehouse).
 2. The item **Description** auto-populates.
 3. Select an optional **Batch No** (filtered to batches in the WIP warehouse for the selected item).
-4. **Available Qty** shows the quantity in the WIP warehouse for that batch/item.
-5. Enter **Qty** (must not exceed available qty when a batch is specified).
-6. Click **Add** to add the row. Repeat for additional items.
-7. Click **Post Consumption** — the server creates a single `Material Consumption for Manufacture` SE covering all rows, validating BOM membership and the over-consumption threshold.
-8. The materials snapshot refreshes on success.
+4. **Required Qty** shows the BOM/planned requirement for this item on the current Work Order.
+5. **Remaining Qty** shows `max(required - already consumed for this WO, 0)` — use this as the primary decision aid.
+6. **Available Qty in WIP** shows the quantity in the WIP warehouse for that batch/item.
+7. Enter **Qty** (must not exceed Available Qty in WIP when a batch is specified). Remaining Qty is informational and does not block entry above it (the server's over-consumption threshold still applies).
+8. Click **Add** to add the row. Repeat for additional items.
+9. Click **Post Consumption** — the server creates a single `Material Consumption for Manufacture` SE covering all rows, validating BOM membership and the over-consumption threshold.
+10. The materials snapshot refreshes on success.
 
 ---
 

--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -3177,6 +3177,68 @@ def get_batch_available_qty(work_order: str, item_code: str, batch_no: str):
 
 
 @frappe.whitelist()
+def get_manual_load_item_context(work_order: str, item_code: str):
+    """
+    Return BOM-required, consumed and remaining quantities for a given item on
+    a Work Order. Used by the Manual Load dialog to give operators WO-specific
+    context alongside the existing WIP availability figure.
+
+    Required qty is computed using the same scaling logic as
+    get_materials_snapshot (BOM item qty * WO/BOM factor).
+
+    Consumed qty sums submitted "Material Consumption for Manufacture" Stock
+    Entries for this WO/item, ignoring finished/scrap rows.
+    """
+    _require_roles(["Factory Operator", "Stores User", "Production Manager"])
+
+    item_code = (item_code or "").strip()
+    if not work_order or not item_code:
+        return {
+            "item_code": item_code,
+            "uom": "",
+            "required_qty": 0.0,
+            "consumed_qty": 0.0,
+            "remaining_qty": 0.0,
+        }
+
+    wo = frappe.get_doc("Work Order", work_order)
+    uom = frappe.db.get_value("Item", item_code, "stock_uom") or "Nos"
+
+    required_qty = 0.0
+    if wo.get("bom_no"):
+        bom = frappe.get_doc("BOM", wo.bom_no)
+        bom_qty = float(bom.get("quantity") or 1) or 1
+        wo_qty = float(wo.get("qty") or 0)
+        factor = wo_qty / bom_qty if bom_qty else 1.0
+        for it in bom.items:
+            if it.item_code == item_code:
+                required_qty += float(it.qty or 0) * factor
+
+    consumed_row = frappe.db.sql("""
+        SELECT COALESCE(SUM(sed.qty), 0) AS total
+        FROM `tabStock Entry` se
+        JOIN `tabStock Entry Detail` sed ON sed.parent = se.name
+        WHERE se.docstatus = 1
+          AND se.work_order = %s
+          AND se.purpose = 'Material Consumption for Manufacture'
+          AND sed.item_code = %s
+          AND sed.is_finished_item = 0
+          AND sed.is_scrap_item = 0
+    """, (work_order, item_code))
+    consumed_qty = float((consumed_row and consumed_row[0][0]) or 0)
+
+    remaining_qty = max(required_qty - consumed_qty, 0.0)
+
+    return {
+        "item_code": item_code,
+        "uom": uom,
+        "required_qty": required_qty,
+        "consumed_qty": consumed_qty,
+        "remaining_qty": remaining_qty,
+    }
+
+
+@frappe.whitelist()
 def manual_load_materials(work_order: str, items: str):
     """
     Manually consume materials from WIP warehouse into a Work Order without barcode scanning.

--- a/isnack/isnack/page/operator_hub/operator_hub.css
+++ b/isnack/isnack/page/operator_hub/operator_hub.css
@@ -774,6 +774,14 @@ body[data-route="operator-hub"].op-kiosk #kiosk-exit:hover{ opacity:1; }
   color: #9f1239 !important;
 }
 
+/* Required Qty / Remaining Qty — neutral informational style */
+.manual-load-dialog [data-fieldname="required_qty"] .form-control,
+.manual-load-dialog [data-fieldname="remaining_qty"] .form-control{
+  background: #f8fafc !important;
+  border-color: #cbd5e1 !important;
+  color: #334155 !important;
+}
+
 /* Add button — teal accent matching theme */
 .manual-load-dialog .ml-add-btn{
   background: #15b79e !important;

--- a/isnack/isnack/page/operator_hub/operator_hub.js
+++ b/isnack/isnack/page/operator_hub/operator_hub.js
@@ -813,7 +813,9 @@ function init_operator_hub($root) {
         },
         { label: 'Description', fieldname: 'item_desc', fieldtype: 'Small Text', read_only: 1 },
         { label: 'Batch No', fieldname: 'batch_no', fieldtype: 'Link', options: 'Batch', reqd: 0 },
-        { label: 'Available Qty', fieldname: 'available_qty', fieldtype: 'Float', read_only: 1 },
+        { label: 'Required Qty', fieldname: 'required_qty', fieldtype: 'Float', read_only: 1 },
+        { label: 'Remaining Qty', fieldname: 'remaining_qty', fieldtype: 'Float', read_only: 1 },
+        { label: 'Available Qty in WIP', fieldname: 'available_qty', fieldtype: 'Float', read_only: 1 },
         { label: 'Qty', fieldname: 'qty', fieldtype: 'Float', reqd: 0 },
         { fieldname: 'list', fieldtype: 'HTML', options: listHTML },
       ],
@@ -835,11 +837,13 @@ function init_operator_hub($root) {
       }
     });
 
-    // When item_code changes: fetch description, clear batch/qty, update batch filter
+    // When item_code changes: fetch description + WO context, clear batch/qty, update batch filter
     d.fields_dict.item_code.df.onchange = function() {
       const item_code = (d.get_value('item_code') || '').trim();
       d.set_value('item_desc', '');
       d.set_value('batch_no', '');
+      d.set_value('required_qty', 0);
+      d.set_value('remaining_qty', 0);
       d.set_value('available_qty', 0);
       d.set_value('qty', 0);
       if (!item_code) return;
@@ -847,6 +851,31 @@ function init_operator_hub($root) {
       // Fetch item description
       frappe.db.get_value('Item', item_code, 'description').then(r => {
         if (r && r.message) d.set_value('item_desc', r.message.description || '');
+      });
+
+      // Fetch WO-specific required/remaining context for this item
+      rpc('isnack.api.mes_ops.get_manual_load_item_context', {
+        work_order: state.current_wo,
+        item_code
+      }).then(r => {
+        const msg = r && r.message;
+        if (!msg) return;
+        d.set_value('required_qty', parseFloat(msg.required_qty) || 0);
+        d.set_value('remaining_qty', parseFloat(msg.remaining_qty) || 0);
+      });
+
+      // Populate item-level WIP availability when no batch is selected
+      rpc('isnack.api.mes_ops.get_batch_available_qty', {
+        work_order: state.current_wo,
+        item_code,
+        batch_no: ''
+      }).then(r => {
+        const msg = r && r.message;
+        if (!msg) return;
+        // Only apply if user has not yet picked a batch
+        if (!(d.get_value('batch_no') || '').trim()) {
+          d.set_value('available_qty', parseFloat(msg.qty) || 0);
+        }
       });
 
       // Update batch filter to show only batches in staging for this item/WO
@@ -857,13 +886,13 @@ function init_operator_hub($root) {
       };
     };
 
-    // When batch_no changes: fetch available qty from WIP
+    // When batch_no changes: fetch available qty from WIP (batch-specific or item-level)
     d.fields_dict.batch_no.df.onchange = function() {
       const item_code = (d.get_value('item_code') || '').trim();
       const batch_no  = (d.get_value('batch_no')  || '').trim();
       d.set_value('available_qty', 0);
       d.set_value('qty', 0);
-      if (!item_code || !batch_no) return;
+      if (!item_code) return;
 
       rpc('isnack.api.mes_ops.get_batch_available_qty', {
         work_order: state.current_wo,
@@ -902,6 +931,7 @@ function init_operator_hub($root) {
       if (batch_no && qty > avail_qty) { frappe.msgprint(`Qty cannot exceed available qty (${avail_qty})`); return; }
       lines.push({ item_code, qty, batch_no: batch_no || undefined });
       d.set_value('item_code', ''); d.set_value('item_desc', ''); d.set_value('batch_no', '');
+      d.set_value('required_qty', 0); d.set_value('remaining_qty', 0);
       d.set_value('available_qty', 0); d.set_value('qty', 0);
       redraw();
     }


### PR DESCRIPTION
## Summary
Enhanced the Manual Load materials dialog to display Work Order-specific context alongside warehouse availability. Operators now see required quantity (from BOM), consumed quantity (from prior Stock Entries), and remaining quantity to help inform loading decisions.

## Key Changes

**Backend (`isnack/api/mes_ops.py`)**
- Added `get_manual_load_item_context()` endpoint that returns:
  - `required_qty`: Scaled from BOM item quantity using WO/BOM factor
  - `consumed_qty`: Sum of submitted "Material Consumption for Manufacture" Stock Entries for the WO/item
  - `remaining_qty`: `max(required - consumed, 0)`
  - `uom`: Item's stock unit of measure
- Includes role-based access control (Factory Operator, Stores User, Production Manager)

**Frontend (`isnack/isnack/page/operator_hub/operator_hub.js`)**
- Added two new read-only fields to the Manual Load dialog:
  - **Required Qty**: Shows BOM-scaled requirement for the current WO
  - **Remaining Qty**: Shows guidance quantity (required minus already consumed)
- Renamed "Available Qty" to "Available Qty in WIP" for clarity
- Updated item_code change handler to:
  - Fetch WO-specific context via new endpoint
  - Fetch item-level WIP availability when no batch is selected
  - Clear context fields when item changes
- Updated batch_no change handler to allow fetching availability without requiring a batch selection
- Reset context fields when adding items to the consumption list

**Styling (`isnack/isnack/page/operator_hub/operator_hub.css`)**
- Added neutral styling for Required Qty and Remaining Qty fields (light slate background)

**Documentation**
- Updated README.md, storekeeper-operator-hub-flow.md, and production-plan-to-operator-hub-guide.md to reflect:
  - New Required Qty and Remaining Qty fields
  - Clarified "Available Qty in WIP" terminology
  - Explained that Remaining Qty is informational and does not block entry (server-side over-consumption threshold still applies)
  - Updated step numbering to reflect new workflow

## Implementation Details
- Required quantity calculation uses the same BOM scaling logic as `get_materials_snapshot()`
- Consumed quantity query filters for submitted Stock Entries with purpose "Material Consumption for Manufacture", excluding finished/scrap rows
- Item-level WIP availability is fetched when no batch is selected, providing a fallback context
- Remaining Qty serves as guidance only; actual validation against batch availability occurs when a batch is selected

https://claude.ai/code/session_01HNBGyaRqV1XcDfKCmnpTFo