### PR TITLE
Block material operations after End WO until Close Production

### DIFF
--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -793,15 +793,28 @@ def get_wo_banner(work_order):
     type_chip = "FG" if is_fg else "SF"
     batch = wo.get("batch_no") or "-"
     line = _line_for_work_order(work_order) or "-"
+    ended = bool(wo.get("custom_production_ended"))
+    ended_badge = (
+        ' <span class="badge bg-dark ms-2">Production Ended</span>' if ended else ""
+    )
+    ended_note = (
+        '<div class="small" style="color:#92400e;">'
+        '<b>Production ended</b> — awaiting Close Production. '
+        'No further material loading allowed.'
+        "</div>"
+        if ended
+        else ""
+    )
 
     html = f"""
       <div class="d-flex flex-wrap justify-content-between">
         <div><b>{frappe.utils.escape_html(wo.name)}</b> — {frappe.utils.escape_html(wo.item_name)}</div>
-        <div><span class="badge {'bg-primary' if is_fg else 'bg-secondary'}">{type_chip}</span></div>
+        <div><span class="badge {'bg-primary' if is_fg else 'bg-secondary'}">{type_chip}</span>{ended_badge}</div>
       </div>
       <div>Batch: {frappe.utils.escape_html(batch)}</div>
       <div>Target: {wo.qty} &nbsp; Actual: {actual} &nbsp; Rejects: {rejects} &nbsp; Status: {frappe.utils.escape_html(wo.status)}</div>
       <div class="small text-muted">Line: {frappe.utils.escape_html(line)} · Operator: {frappe.utils.escape_html(frappe.session.user)}</div>
+      {ended_note}
     """
     return {"html": html}
 
@@ -1043,6 +1056,9 @@ def set_work_order_state(
 
     now = frappe.utils.now_datetime()
     action_lc = (action or "").strip().lower()
+    # Block any state change that resumes production after End WO.
+    if action_lc in ("start", "resume", "reopen"):
+        _assert_not_ended(work_order)
     updates: dict = {}
     stage_status = _storekeeper_stage_status(work_order)
     if stage_status != "Staged" and action_lc in ("start", "pause", "stop", "resume", "reopen"):
@@ -1346,6 +1362,9 @@ def scan_material(code, job_card: Optional[str] = None, work_order: Optional[str
         if not work_order:
             frappe.throw(_("Missing work_order / job_card"))
 
+        # Block scans on ended Work Orders.
+        _assert_not_ended(work_order)
+
         # Duplicate-scan guard
         if _has_recent_duplicate(work_order, code):
             return {"ok": False, "msg": _("Duplicate scan ignored")}
@@ -1498,6 +1517,8 @@ def request_material(item_code, qty, reason=None, job_card: Optional[str] = None
         work_order = frappe.db.get_value("Job Card", job_card, "work_order")
     if not work_order:
         frappe.throw(_("Missing work_order / job_card"))
+
+    _assert_not_ended(work_order)
 
     central_wh = frappe.db.get_single_value("Stock Settings", "default_warehouse")
     projected_qty = frappe.db.get_value("Bin", {"warehouse": central_wh, "item_code": item_code}, "projected_qty") or 0
@@ -1725,6 +1746,22 @@ def complete_work_order(work_order, good, rejects=0, remarks=None, sfg_usage=Non
     wo.flags.ignore_permissions = True
     wo.save()
     return True
+
+def _assert_not_ended(work_order: str) -> None:
+    """Block any material movement / state change once End WO has been pressed.
+
+    Source-of-truth guard used by scan, manual load, and Start/Resume so a stale
+    UI tab cannot keep posting against an ended Work Order. Cleared by
+    `close_production` when it sets `custom_production_ended = 0`.
+    """
+    if not work_order:
+        return
+    if frappe.db.get_value("Work Order", work_order, "custom_production_ended"):
+        frappe.throw(
+            _("Work Order {0} has been ended; further material movements are "
+              "not allowed until Close Production.").format(work_order)
+        )
+
 
 @frappe.whitelist()
 def end_work_order(work_order: str, sfg_usage: str = None):
@@ -3252,6 +3289,8 @@ def manual_load_materials(work_order: str, items: str):
 
     if not work_order:
         frappe.throw(_("Missing work_order"))
+
+    _assert_not_ended(work_order)
 
     try:
         item_list = json.loads(items) if isinstance(items, str) else items

--- a/isnack/isnack/page/operator_hub/operator_hub.css
+++ b/isnack/isnack/page/operator_hub/operator_hub.css
@@ -199,6 +199,9 @@
 .op-teal .chip-allocated{ background:#ecfdf5; color:#047857; border-color:#a7f3d0; }
 .op-teal .chip-partial{ background:#fef3c7; color:#92400e; border-color:#fde68a; }
 .op-teal .chip-not-allocated{ background:#f3f4f6; color:#6b7280; border-color:#e5e7eb; }
+.op-teal .chip-ended{ background:#1f2937; color:#f9fafb; border-color:#111827; }
+.op-teal .row-ended{ opacity:.65; }
+.op-teal .row-ended .fw-semibold{ text-decoration: line-through; text-decoration-color: #6b7280; }
 
 /* Scan input */
 .op-teal #scan{

--- a/isnack/isnack/page/operator_hub/operator_hub.js
+++ b/isnack/isnack/page/operator_hub/operator_hub.js
@@ -361,11 +361,15 @@ function init_operator_hub($root) {
     const hasWO   = !!state.current_wo;
     const enableCore = hasEmp && hasWO;
     const isAllocated = state.current_stage_status === 'Staged';
+    const isProductionEnded = state.current_production_ended || false;
     const enableActions = enableCore && isAllocated;
+    // Once production has been ended, all material-movement / state-change
+    // actions on this WO are blocked until Close Production runs.
+    const enableLiveActions = enableActions && !isProductionEnded;
     const status = state.current_wo_status;
 
     // Enable Start button only if status is "Not Started" and fully allocated
-    const isStartDisabled = !enableActions || status !== "Not Started";
+    const isStartDisabled = !enableLiveActions || status !== "Not Started";
     $('#btn-start',  $root).prop('disabled', isStartDisabled);
 
     // Dynamic Pause/Resume button
@@ -375,21 +379,22 @@ function init_operator_hub($root) {
     } else {
       $pauseBtn.text('Pause').removeClass('btn-success').addClass('btn-warning');
     }
-    $pauseBtn.prop('disabled', !enableActions);
+    $pauseBtn.prop('disabled', !enableLiveActions);
 
-    $('#btn-load',        $root).prop('disabled', !enableActions);
-    $('#btn-manual-load', $root).prop('disabled', !enableActions);
-    $('#btn-request', $root).prop('disabled', !enableActions);
+    $('#btn-load',        $root).prop('disabled', !enableLiveActions);
+    $('#btn-manual-load', $root).prop('disabled', !enableLiveActions);
+    $('#btn-request', $root).prop('disabled', !enableLiveActions);
+    // Return is left available after End WO so operators can still return
+    // surplus staged material before Close Production sweeps the WO.
     $('#btn-return',  $root).prop('disabled', !enableActions);
-    
+
     // End Shift Return only requires operator and line (no work order needed)
     $('#btn-end-shift-return', $root).prop('disabled', !(hasEmp && state.current_lines.length));
 
-    $('#btn-label', $root).prop('disabled', !(enableActions && state.current_lines.length));
+    $('#btn-label', $root).prop('disabled', !(enableLiveActions && state.current_lines.length));
     $('#btn-label-history', $root).prop('disabled', !(enableActions && state.current_is_fg));
-    
+
     // End WO button: enabled when operator set + WO selected + WO allocated + not already ended
-    const isProductionEnded = state.current_production_ended || false;
     $('#btn-end-wo', $root).prop('disabled', !(enableActions && !isProductionEnded));
     
     // Close Production button: enabled when operator set + line(s) set (no specific WO required)
@@ -592,8 +597,11 @@ function init_operator_hub($root) {
         'Stopped':'chip chip-paused',
         'Completed':'chip chip-running'
       }[row.status] || 'chip chip-ns');
+      const isEnded = !!row.custom_production_ended;
+      const endedChip = isEnded ? '<span class="chip chip-ended" title="Production ended — awaiting Close Production">Ended</span>' : '';
+      const rowClass = isEnded ? ' row-ended' : '';
       const el = $(`
-        <button class="list-group-item list-group-item-action py-3 d-flex justify-content-between align-items-center" type="button">
+        <button class="list-group-item list-group-item-action py-3 d-flex justify-content-between align-items-center${rowClass}" type="button">
           <div class="fw-semibold">
             <span class="me-2">${frappe.utils.escape_html(row.name)}</span>
             <span class="text-muted">— ${frappe.utils.escape_html(row.item_name || '')}</span>
@@ -604,6 +612,7 @@ function init_operator_hub($root) {
             <span class="${chipType}">${row.type}</span>
             ${allocChip}
             <span class="${stClass}">${row.status}</span>
+            ${endedChip}
           </div>
         </button>
       `);
@@ -640,6 +649,11 @@ function init_operator_hub($root) {
     }
     if (!state.current_emp) { ensureOperatorNotice(); try { errTone.play().catch(()=>{}); } catch(_) {} return; }
     if (!state.current_wo){ flashStatus('Pick a Work Order first', 'warning'); try { errTone.play().catch(()=>{}); } catch(_) {} return; }
+    if (state.current_production_ended) {
+      flashStatus('Work Order has been ended — no further loading allowed', 'error');
+      try { errTone.play().catch(()=>{}); } catch(_) {}
+      return;
+    }
 
     setStatus('Processing scan…');
     
@@ -1775,10 +1789,19 @@ function init_operator_hub($root) {
         rpc('isnack.api.mes_ops.end_work_order', {
           work_order: state.current_wo,
           sfg_usage: JSON.stringify(sfgUsage),
-        }).then(() => {
+        }).then(async () => {
           d.hide();
-          flashStatus(`Ended — ${state.current_wo}`, 'success');
-          load_queue();
+          const endedWo = state.current_wo;
+          // Optimistically reflect ended state so the UI updates immediately.
+          state.current_production_ended = true;
+          refreshButtonStates();
+          flashStatus(`Ended — ${endedWo}`, 'success');
+          // Refresh queue (re-renders the row with the Ended chip) and re-select
+          // the same WO so the banner re-fetches with the ended note.
+          await load_queue();
+          if (endedWo && (state.orders || []).find(o => o.name === endedWo)) {
+            set_active_work_order(endedWo);
+          }
         });
       }
     });


### PR DESCRIPTION
## Summary
This PR implements a production-ended state that prevents further material movement and state changes on a Work Order after the "End WO" button is pressed, until the "Close Production" operation completes. This ensures operators cannot continue loading materials or resuming production on a WO that has been formally ended.

## Key Changes

**Backend (mes_ops.py):**
- Added `_assert_not_ended()` helper function that checks if a Work Order has `custom_production_ended` set and throws an error if so
- Integrated the guard into three critical operations:
  - `scan_material()` - blocks material scans on ended WOs
  - `request_material()` - blocks material requests on ended WOs
  - `set_work_order_state()` - blocks Start/Resume/Reopen actions on ended WOs
  - `manual_load_materials()` - blocks manual material loading on ended WOs
- Enhanced `get_wo_banner()` to display a "Production Ended" badge and informational note when a WO is ended

**Frontend (operator_hub.js):**
- Introduced `isProductionEnded` state variable and `enableLiveActions` flag to distinguish between actions allowed after End WO (like Return) vs. those that should be blocked
- Updated button disable logic:
  - Start, Pause/Resume, Load, Manual Load, Request, and Label buttons now use `enableLiveActions` (blocked after End WO)
  - Return button remains available after End WO so operators can return surplus staged material
  - End WO button properly checks the ended state
- Enhanced work order list rendering to show an "Ended" chip on ended WOs with visual styling (darkened row with strikethrough text)
- Modified `end_work_order()` callback to optimistically update UI state and refresh the queue/selection so the ended state is immediately reflected

**Styling (operator_hub.css):**
- Added `.chip-ended` styling for the ended status indicator
- Added `.row-ended` styling to visually distinguish ended work orders (reduced opacity with strikethrough text)

## Implementation Details
- The `custom_production_ended` field serves as the source-of-truth for the ended state
- The guard is cleared when `close_production` sets `custom_production_ended = 0`
- UI updates optimistically after End WO to provide immediate feedback while the backend processes
- Return operations remain available post-End WO to allow cleanup of staged materials before Close Production

https://claude.ai/code/session_01Rx8ZtmyzgCJ5q712g3SpDc