### PR TITLE
Operator Hub: enforce BOM consumption before End WO

### DIFF
--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -1763,8 +1763,113 @@ def _assert_not_ended(work_order: str) -> None:
         )
 
 
+# Default tolerance applied to End WO consumption check when Factory Settings
+# does not define `end_wo_tolerance_pct`. Expressed as a percent of required qty.
+END_WO_DEFAULT_TOLERANCE_PCT = 2.0
+ROLES_END_WO_OVERRIDE = ["Production Manager"]
+
+
+def _end_wo_tolerance_pct() -> float:
+    """Read End WO tolerance % from Factory Settings, falling back to the
+    default. The Factory Settings field is optional; if it does not exist we
+    silently use the default constant."""
+    try:
+        val = frappe.db.get_single_value("Factory Settings", "end_wo_tolerance_pct")
+        if val is not None and float(val) >= 0:
+            return float(val)
+    except Exception:
+        pass
+    return END_WO_DEFAULT_TOLERANCE_PCT
+
+
+def _end_wo_consumption_summary(work_order: str) -> dict:
+    """Compute required vs consumed for each BOM item on the WO.
+
+    Returns a dict with:
+      - tolerance_pct: float
+      - items: list of rows (excluding SFG components, which are handled
+        separately via the End WO dialog's SFG section). Each row:
+          {item_code, item_name, uom, required, consumed, remaining,
+           is_packaging, is_sfg, status}
+        status ∈ {"ok", "short", "over"}.
+      - shortfalls: count of items with status == "short" (non-SFG only)
+      - can_end: True iff there are no shortfalls
+    """
+    tolerance_pct = _end_wo_tolerance_pct()
+    out = {"tolerance_pct": tolerance_pct, "items": [], "shortfalls": 0, "can_end": True}
+
+    wo = frappe.get_doc("Work Order", work_order)
+    if not wo.bom_no:
+        return out
+
+    bom_items = _get_bom_items_for_quantity(wo.bom_no, flt(wo.qty))
+    consumed_map = _get_consumed_materials_from_load(work_order)
+
+    sfg_codes = {row["item_code"] for row in (get_sfg_components_for_wo(work_order).get("items") or [])}
+    packaging_groups = _packaging_groups_global()
+
+    rows: list[dict] = []
+    shortfalls = 0
+    for bi in bom_items:
+        item_code = bi["item_code"]
+        required = float(bi.get("qty") or 0)
+        consumed = float(consumed_map.get(item_code, 0) or 0)
+        remaining = required - consumed
+        group = (_get_item_group(item_code) or "").strip().lower()
+        is_packaging = group in packaging_groups
+        is_sfg = item_code in sfg_codes
+        allowed_short = required * (tolerance_pct / 100.0)
+
+        if remaining > allowed_short + QTY_EPSILON:
+            status = "short"
+        elif remaining < -QTY_EPSILON:
+            status = "over"
+        else:
+            status = "ok"
+
+        # SFG items are handled by the SFG section of the dialog and are
+        # excluded from the "must be consumed" gate.
+        if not is_sfg and status == "short":
+            shortfalls += 1
+
+        rows.append(
+            {
+                "item_code": item_code,
+                "item_name": frappe.db.get_value("Item", item_code, "item_name") or item_code,
+                "uom": bi.get("uom") or "",
+                "required": required,
+                "consumed": consumed,
+                "remaining": remaining,
+                "is_packaging": is_packaging,
+                "is_sfg": is_sfg,
+                "status": status,
+            }
+        )
+
+    out["items"] = rows
+    out["shortfalls"] = shortfalls
+    out["can_end"] = shortfalls == 0
+    return out
+
+
 @frappe.whitelist()
-def end_work_order(work_order: str, sfg_usage: str = None):
+def get_end_wo_summary(work_order: str):
+    """Snapshot used by the Operator Hub End WO dialog.
+
+    Combines the consumption summary with the existing SFG component list and
+    a flag indicating whether the current user can override a shortfall.
+    """
+    _require_roles(ROLES_OPERATOR)
+    summary = _end_wo_consumption_summary(work_order)
+    summary["sfg_items"] = (get_sfg_components_for_wo(work_order) or {}).get("items") or []
+    user_roles = set(frappe.get_roles(frappe.session.user))
+    summary["can_override"] = bool(set(ROLES_END_WO_OVERRIDE) & user_roles)
+    return summary
+
+
+@frappe.whitelist()
+def end_work_order(work_order: str, sfg_usage: str = None,
+                   override_reason: str = None):
     """
     End a work order - consume SFG materials and mark as ended.
     Does NOT create Manufacture Stock Entry.
@@ -1776,15 +1881,15 @@ def end_work_order(work_order: str, sfg_usage: str = None):
     _require_roles(ROLES_OPERATOR)
 
     wo = frappe.get_doc("Work Order", work_order)
-    
+
     # Validate WO status - must be In Process or Not Started with allocation
     if wo.status not in ("Not Started", "In Process"):
         frappe.throw(_("Work Order must be 'Not Started' or 'In Process' to end"))
-    
+
     # Check if already ended
     if wo.get("custom_production_ended"):
         frappe.throw(_("Work Order is already ended"))
-    
+
     # Parse and post SFG consumption if provided
     sfg_rows: list[dict] = []
     if sfg_usage:
@@ -1798,11 +1903,49 @@ def end_work_order(work_order: str, sfg_usage: str = None):
 
     if sfg_rows:
         _post_sfg_consumption(wo, sfg_rows, 0)  # fg_completed_qty = 0 since we're not creating FG yet
-    
+
+    # Tolerance-based check: every required (non-SFG) BOM item must be
+    # consumed at or above (required - tolerance). Production Managers can
+    # override with a written reason which is stored on the WO for audit.
+    summary = _end_wo_consumption_summary(work_order)
+    if not summary["can_end"]:
+        reason = (override_reason or "").strip()
+        user_roles = set(frappe.get_roles(frappe.session.user))
+        is_override_allowed = bool(set(ROLES_END_WO_OVERRIDE) & user_roles)
+
+        short_rows = [r for r in summary["items"] if (not r["is_sfg"]) and r["status"] == "short"]
+        short_summary = ", ".join(
+            f"{r['item_code']} ({r['consumed']:.4g}/{r['required']:.4g} {r['uom']})"
+            for r in short_rows
+        )
+
+        if not reason:
+            frappe.throw(
+                _(
+                    "Cannot end Work Order: {0} required item(s) below tolerance "
+                    "({1}%): {2}. All required materials must be consumed "
+                    "(within tolerance) before ending."
+                ).format(summary["shortfalls"], summary["tolerance_pct"], short_summary)
+            )
+        if not is_override_allowed:
+            frappe.throw(
+                _(
+                    "Only a Production Manager can force-end an under-consumed "
+                    "Work Order. Shortfall: {0}."
+                ).format(short_summary)
+            )
+        # Reason supplied + manager role: log and continue.
+        wo.add_comment(
+            "Info",
+            _(
+                "End WO override by {0}. Shortfall (>{1}% tolerance): {2}. Reason: {3}"
+            ).format(frappe.session.user, summary["tolerance_pct"], short_summary, reason),
+        )
+
     # Mark as ended
     wo.db_set("custom_production_ended", 1, commit=True)
     wo.add_comment("Info", _("Work Order ended - awaiting production closure"))
-    
+
     return {"success": True, "message": "Work Order ended successfully"}
 
 @frappe.whitelist()

--- a/isnack/isnack/page/operator_hub/operator_hub.js
+++ b/isnack/isnack/page/operator_hub/operator_hub.js
@@ -1732,26 +1732,82 @@ function init_operator_hub($root) {
     await showLabelHistoryDialog();
   });
 
-  // >>> NEW: End WO - Mark work order as ended and consume semi-finished materials <<<
+  // >>> End WO - consume SFG, enforce BOM consumption tolerance, mark ended <<<
+  function renderEndWoSummaryHtml(summary) {
+    const tol = (summary && summary.tolerance_pct != null) ? summary.tolerance_pct : 0;
+    const items = (summary && summary.items) || [];
+    if (!items.length) {
+      return '<div class="text-muted small">No BOM items found for this Work Order.</div>';
+    }
+    const fmt = (n) => {
+      if (n == null) return '0';
+      const v = Number(n);
+      return Number.isInteger(v) ? String(v) : v.toFixed(3).replace(/\.?0+$/, '');
+    };
+    const rows = items.map(it => {
+      let badge, badgeText;
+      if (it.is_sfg) {
+        badge = 'bg-secondary'; badgeText = 'SFG (enter below)';
+      } else if (it.status === 'ok') {
+        badge = 'bg-success'; badgeText = 'OK';
+      } else if (it.status === 'over') {
+        badge = 'bg-warning text-dark'; badgeText = 'Over';
+      } else {
+        badge = 'bg-danger'; badgeText = 'Short';
+      }
+      const remainingDisplay = it.remaining > 0 ? fmt(it.remaining) : (it.remaining < 0 ? `+${fmt(-it.remaining)}` : '0');
+      return `
+        <tr>
+          <td>${frappe.utils.escape_html(it.item_code)}</td>
+          <td class="small text-muted">${frappe.utils.escape_html(it.item_name || '')}</td>
+          <td class="text-end">${fmt(it.required)}</td>
+          <td class="text-end">${fmt(it.consumed)}</td>
+          <td class="text-end">${remainingDisplay} ${frappe.utils.escape_html(it.uom || '')}</td>
+          <td><span class="badge ${badge}">${badgeText}</span></td>
+        </tr>`;
+    }).join('');
+    const shortfalls = (summary && summary.shortfalls) || 0;
+    const headline = shortfalls
+      ? `<div class="alert alert-danger py-2 mb-2"><b>${shortfalls} item(s)</b> below tolerance (${tol}%). Consume the missing materials, or a Production Manager may override with a written reason.</div>`
+      : `<div class="alert alert-success py-2 mb-2">All required materials consumed (within ${tol}% tolerance).</div>`;
+    return `
+      ${headline}
+      <div class="table-responsive">
+        <table class="table table-sm table-bordered mb-0">
+          <thead><tr>
+            <th>Item</th><th>Name</th>
+            <th class="text-end">Required</th>
+            <th class="text-end">Consumed</th>
+            <th class="text-end">Remaining</th>
+            <th>Status</th>
+          </tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>`;
+  }
+
   $('#btn-end-wo',$root).on('click', async () => {
     if (!state.current_wo || !state.current_emp) { ensureOperatorNotice(); return; }
     setScanMode(false);
 
-    // Get semi-finished components (slurry / rice mix etc.) for this WO
-    let sfgRows = [];
+    let summary = { items: [], sfg_items: [], shortfalls: 0, can_end: true,
+                    tolerance_pct: 0, can_override: false };
     try {
-      const r2 = await rpc('isnack.api.mes_ops.get_sfg_components_for_wo', { work_order: state.current_wo });
-      sfgRows = (r2.message && r2.message.items) || [];
+      const r = await rpc('isnack.api.mes_ops.get_end_wo_summary', { work_order: state.current_wo });
+      summary = Object.assign(summary, r.message || {});
     } catch (e) {
-      console.warn('get_sfg_components_for_wo failed', e);
+      console.warn('get_end_wo_summary failed', e);
     }
+    const sfgRows = summary.sfg_items || [];
+    const canEnd = !!summary.can_end;
+    const canOverride = !!summary.can_override;
 
     const fields = [];
+    fields.push({ fieldtype: 'HTML', fieldname: 'consumption_summary' });
 
     if (sfgRows.length) {
       fields.push({ fieldtype: 'Section Break', label: 'Semi-finished usage (slurry / rice mix)' });
       fields.push({ fieldtype: 'HTML', fieldname: 'sfg_help' });
-
       sfgRows.forEach((row, idx) => {
         fields.push({
           label: `${(row.item_code || '')} — ${(row.item_name || '')}`,
@@ -1761,54 +1817,78 @@ function init_operator_hub($root) {
           description: row.uom ? `UOM: ${row.uom}` : '',
         });
       });
-    } else {
-      fields.push({ 
-        fieldtype: 'HTML', 
-        fieldname: 'no_sfg_help',
-        options: '<div class="text-muted">No semi-finished materials to record. Click End WO to mark this work order as ended.</div>'
+    }
+
+    if (!canEnd && canOverride) {
+      fields.push({ fieldtype: 'Section Break', label: 'Manager override' });
+      fields.push({
+        fieldtype: 'HTML', fieldname: 'override_help',
+        options: '<div class="text-muted small mb-2">As a Production Manager you can force-end this WO. The reason below is logged on the Work Order for audit.</div>'
+      });
+      fields.push({
+        fieldtype: 'Small Text', fieldname: 'override_reason',
+        label: 'Reason for shortfall', reqd: 1,
+      });
+    } else if (!canEnd && !canOverride) {
+      fields.push({ fieldtype: 'Section Break' });
+      fields.push({
+        fieldtype: 'HTML', fieldname: 'no_override_help',
+        options: '<div class="text-muted small">A Production Manager must force-end this Work Order while a shortfall exists.</div>'
       });
     }
 
-    const d = new frappe.ui.Dialog({
-      title:'End Work Order',
+    const dialog_opts = {
+      title: 'End Work Order',
       fields,
-      primary_action_label:'End WO',
+      primary_action_label: 'End WO',
       primary_action: (v) => {
+        // Re-evaluate using the most recently rendered summary.
+        if (!canEnd && !canOverride) {
+          flashStatus('Cannot end: required materials below tolerance', 'error');
+          return;
+        }
+        if (!canEnd && canOverride && !(v.override_reason || '').trim()) {
+          flashStatus('Reason for shortfall is required to override', 'warning');
+          return;
+        }
         setStatus('Ending work order…');
-
         const sfgUsage = [];
         sfgRows.forEach((row, idx) => {
-          const key = `sfg_${idx}`;
-          const rawVal = v[key];
-          const qty = parseFloat(rawVal || 0);
-          if (qty > 0) {
-            sfgUsage.push({ item_code: row.item_code, qty: qty });
-          }
+          const qty = parseFloat(v[`sfg_${idx}`] || 0);
+          if (qty > 0) sfgUsage.push({ item_code: row.item_code, qty });
         });
-
-        rpc('isnack.api.mes_ops.end_work_order', {
+        const args = {
           work_order: state.current_wo,
           sfg_usage: JSON.stringify(sfgUsage),
-        }).then(async () => {
+        };
+        if (!canEnd && canOverride) args.override_reason = (v.override_reason || '').trim();
+        rpc('isnack.api.mes_ops.end_work_order', args).then(async () => {
           d.hide();
           const endedWo = state.current_wo;
-          // Optimistically reflect ended state so the UI updates immediately.
           state.current_production_ended = true;
           refreshButtonStates();
           flashStatus(`Ended — ${endedWo}`, 'success');
-          // Refresh queue (re-renders the row with the Ended chip) and re-select
-          // the same WO so the banner re-fetches with the ended note.
           await load_queue();
           if (endedWo && (state.orders || []).find(o => o.name === endedWo)) {
             set_active_work_order(endedWo);
           }
-        });
-      }
-    });
+        }).catch(() => {/* server-side message already shown */});
+      },
+    };
+    const d = new frappe.ui.Dialog(dialog_opts);
 
-    const f = d.get_field('sfg_help');
-    if (f && f.$wrapper) {
-      f.$wrapper.html('<div class="text-muted small mb-2">Enter the actual quantities of semi-finished materials used. They will be consumed from the Semi-finished warehouse.</div>');
+    const summaryField = d.get_field('consumption_summary');
+    if (summaryField && summaryField.$wrapper) {
+      summaryField.$wrapper.html(renderEndWoSummaryHtml(summary));
+    }
+    const sfgHelp = d.get_field('sfg_help');
+    if (sfgHelp && sfgHelp.$wrapper) {
+      sfgHelp.$wrapper.html('<div class="text-muted small mb-2">Enter the actual quantities of semi-finished materials used. They will be consumed from the Semi-finished warehouse.</div>');
+    }
+
+    // Disable the End WO submit when we cannot end and the user lacks the override role.
+    if (!canEnd && !canOverride) {
+      d.get_primary_btn().prop('disabled', true).attr('title', 'Required materials below tolerance');
     }
 
     d.show();


### PR DESCRIPTION
End WO now requires every required (non-SFG) BOM line to be consumed at or above (required - tolerance), where tolerance defaults to 2% and can be overridden via Factory Settings.end_wo_tolerance_pct. Production Managers can still force-end an under-consumed WO by entering a written "Reason for shortfall", which is logged as a comment on the Work Order.

The End WO dialog is rebuilt around a new get_end_wo_summary endpoint: it shows a Required / Consumed / Remaining table for every BOM item with green/amber/red status badges, the SFG section is preserved below the table, and the submit button is disabled when shortfalls exist and the user lacks the override role. The previous "No SFG materials to record" empty state is replaced by the consumption summary, so operators always see the production picture before ending the WO.

https://claude.ai/code/session_01Rx8ZtmyzgCJ5q712g3SpDc