### PR TITLE
Operator Hub: scope Request More Material to current WO raw materials

### DIFF
--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -1506,7 +1506,58 @@ def scan_material(code, job_card: Optional[str] = None, work_order: Optional[str
         return {"ok": False, "msg": _("Failed to consume material. Please contact administrator.")}
 
 
+@frappe.whitelist()
+def get_requestable_items_for_wo(work_order: str):
+    """Return leaf BOM raw-material items for the WO that an operator may
+    legitimately request from stores.
+
+    Excludes:
+      - Items that have their own active+default BOM (semi-finished goods —
+        those are produced via sub-WOs, not requested from stores).
+
+    Each row carries `required / consumed / remaining` so the Operator Hub
+    can pre-fill the Qty input and show a shortage hint.
+    """
+    _require_roles(["Stores User", *ROLES_OPERATOR])
+
+    wo = frappe.get_doc("Work Order", work_order)
+    if not wo.bom_no:
+        return {"items": []}
+
+    bom_items = _get_bom_items_for_quantity(wo.bom_no, flt(wo.qty))
+    consumed_map = _get_consumed_materials_from_load(work_order)
+    sfg_codes = {
+        row["item_code"]
+        for row in (get_sfg_components_for_wo(work_order).get("items") or [])
+    }
+
+    out = []
+    for bi in bom_items:
+        item_code = bi["item_code"]
+        if item_code in sfg_codes:
+            continue
+        required = float(bi.get("qty") or 0)
+        consumed = float(consumed_map.get(item_code, 0) or 0)
+        remaining = max(required - consumed, 0)
+        out.append({
+            "item_code": item_code,
+            "item_name": frappe.db.get_value("Item", item_code, "item_name") or item_code,
+            "uom": bi.get("uom") or "",
+            "required": required,
+            "consumed": consumed,
+            "remaining": remaining,
+        })
+    return {"items": out}
+
+
+@frappe.whitelist()
 def request_material(item_code, qty, reason=None, job_card: Optional[str] = None, work_order: Optional[str] = None):
+    """Operator-initiated Material Request for a shortage on the current WO.
+
+    Restricted to leaf BOM raw materials of the Work Order (non-SFG). Always
+    creates a Material Transfer Material Request — central-warehouse / purchase
+    decisions are made by the buyer, not the operator.
+    """
     _require_roles(["Stores User", *ROLES_OPERATOR])
 
     qty = float(qty or 0)
@@ -1520,21 +1571,32 @@ def request_material(item_code, qty, reason=None, job_card: Optional[str] = None
 
     _assert_not_ended(work_order)
 
-    central_wh = frappe.db.get_single_value("Stock Settings", "default_warehouse")
-    projected_qty = frappe.db.get_value("Bin", {"warehouse": central_wh, "item_code": item_code}, "projected_qty") or 0
-    is_purchase_item = bool(frappe.db.get_value("Item", item_code, "is_purchase_item"))
-    mr_type = "Material Transfer" if projected_qty >= qty else ("Purchase" if is_purchase_item else "Material Transfer")
+    requestable = {
+        it["item_code"]
+        for it in (get_requestable_items_for_wo(work_order).get("items") or [])
+    }
+    if item_code not in requestable:
+        frappe.throw(
+            _(
+                "Item {0} is not a raw material of this Work Order, or is a "
+                "semi-finished item (those are produced, not requested)."
+            ).format(item_code)
+        )
 
     mr = frappe.new_doc("Material Request")
-    mr.material_request_type = mr_type
+    mr.material_request_type = "Material Transfer"
     mr.schedule_date = frappe.utils.nowdate()
     mr.work_order = work_order
-    mr.append("items", {"item_code": item_code, "qty": qty, "schedule_date": mr.schedule_date})
+    mr.append("items", {
+        "item_code": item_code,
+        "qty": qty,
+        "schedule_date": mr.schedule_date,
+    })
     if reason:
         mr.notes = reason
     mr.flags.ignore_permissions = True
     mr.insert()
-    return {"ok": True, "mr": mr.name, "type": mr_type}
+    return {"ok": True, "mr": mr.name, "type": "Material Transfer"}
 
 @frappe.whitelist()
 def set_wo_status(work_order, action, reason=None, remarks=None):

--- a/isnack/isnack/page/operator_hub/operator_hub.js
+++ b/isnack/isnack/page/operator_hub/operator_hub.js
@@ -969,24 +969,93 @@ function init_operator_hub($root) {
     redraw();
   });
 
-  $('#btn-request',$root).on('click', () => {
+  $('#btn-request',$root).on('click', async () => {
     if (!state.current_wo || !state.current_emp) { ensureOperatorNotice(); return; }
     setScanMode(false);  // let the dialog keep focus
+
+    // Fetch the WO's leaf BOM raw materials so the Item field is restricted
+    // to materials that actually belong to this Work Order.
+    let items = [];
+    try {
+      const r = await rpc('isnack.api.mes_ops.get_requestable_items_for_wo', { work_order: state.current_wo });
+      items = (r.message && r.message.items) || [];
+    } catch (e) {
+      console.warn('get_requestable_items_for_wo failed', e);
+    }
+    if (!items.length) {
+      flashStatus('No raw materials available to request for this Work Order', 'warning');
+      return;
+    }
+
+    const fmt = (n) => {
+      if (n == null) return '0';
+      const v = Number(n);
+      return Number.isInteger(v) ? String(v) : v.toFixed(3).replace(/\.?0+$/, '');
+    };
+    const itemMap = {};
+    items.forEach(it => { itemMap[it.item_code] = it; });
+    const allowedCodes = items.map(it => it.item_code);
+
     const d = opDialog({
       title:'Request More Material',
       fields: [
-        { label:'Item',   fieldname:'item_code', fieldtype:'Link', options:'Item', reqd:1 },
-        { label:'Qty',    fieldname:'qty', fieldtype:'Float', reqd:1 },
-        { label:'Reason', fieldname:'reason', fieldtype:'Select', options:['Evaporation/Wastage','Overweight Spec','Machine Loss','Short Pick','Other'] }
+        {
+          label:'Item', fieldname:'item_code', fieldtype:'Link', options:'Item', reqd:1,
+          // Restrict the Link autocomplete to this WO's BOM raw materials only.
+          get_query: () => ({ filters: { name: ['in', allowedCodes] } }),
+        },
+        { fieldtype:'HTML', fieldname:'item_hint' },
+        { label:'Qty', fieldname:'qty', fieldtype:'Float', reqd:1 },
+        { label:'Reason', fieldname:'reason', fieldtype:'Select', options:['Evaporation/Wastage','Overweight Spec','Machine Loss','Short Pick','Other'] },
       ],
       primary_action_label:'Send Request',
       primary_action: (v) => {
+        if (!itemMap[v.item_code]) {
+          flashStatus('Pick an item from this Work Order’s BOM', 'warning');
+          return;
+        }
         setStatus('Submitting material request…');
         rpc('isnack.api.mes_ops.request_material', { work_order: state.current_wo, ...v })
-          .then(r => { d.hide(); frappe.msgprint('Material Request: ' + (r.message && r.message.mr)); flashStatus('Material request submitted', 'success'); });
-      }
+          .then(r => {
+            d.hide();
+            const mr = r.message && r.message.mr;
+            frappe.msgprint(mr ? `Material Request created: ${mr}` : 'Material Request created');
+            flashStatus('Material request submitted', 'success');
+          })
+          .catch(() => { /* server-side message already shown */ });
+      },
     });
+
+    // Once an item is picked, default Qty to the remaining shortfall and
+    // show a small Required / Consumed / Remaining hint.
+    const itemField = d.get_field('item_code');
+    const qtyField = d.get_field('qty');
+    const hintField = d.get_field('item_hint');
+    const updateForItem = (code) => {
+      const it = itemMap[code];
+      if (!it) {
+        if (hintField && hintField.$wrapper) hintField.$wrapper.html('');
+        return;
+      }
+      if (qtyField) qtyField.set_value(it.remaining);
+      if (hintField && hintField.$wrapper) {
+        hintField.$wrapper.html(
+          `<div class="text-muted small mb-2">`
+          + `Required <b>${fmt(it.required)} ${frappe.utils.escape_html(it.uom)}</b> &middot; `
+          + `Consumed <b>${fmt(it.consumed)} ${frappe.utils.escape_html(it.uom)}</b> &middot; `
+          + `Remaining <b>${fmt(it.remaining)} ${frappe.utils.escape_html(it.uom)}</b>`
+          + `</div>`
+        );
+      }
+    };
+    if (itemField) {
+      itemField.df.onchange = () => updateForItem(itemField.get_value());
+    }
+
     d.show();
+    // Tag the qty input with the shared "key operator input" style.
+    if (qtyField && qtyField.$input) qtyField.$input.addClass('op-input-key');
+    if (itemField && itemField.$input) itemField.$input.addClass('op-input-info');
   });
 
   // Return Materials


### PR DESCRIPTION
The Item field on Request More Material now lists only the leaf BOM raw materials of the current Work Order (semi-finished components are excluded — those are produced via sub-WOs, not requested from stores). Picking an item pre-fills Qty with the shortfall (required - consumed) and shows a small Required / Consumed / Remaining hint, so the operator sees what they're actually short by.

Backend changes (mes_ops.py):
  - New whitelisted `get_requestable_items_for_wo(work_order)` that returns the WO's leaf BOM rows annotated with required, consumed (from prior Material Consumption for Manufacture entries) and remaining qty.
  - `request_material` now carries `@frappe.whitelist()` (it was missing, so the operator-hub button was silently failing - any "request" issued today never reached the server). It also validates the item is one of the WO's requestable leaf BOM items and always creates a Material Transfer Material Request - the buyer decides whether to raise a Purchase Order against it, not the operator.

The dialog also tags the Item field with op-input-info and the Qty field with op-input-key so it reads consistently with the rest of the themed kiosk dialogs.

https://claude.ai/code/session_01Rx8ZtmyzgCJ5q712g3SpDc