### PR TITLE
Storekeeper Hub: surface and fulfil operator-initiated Material Requests

### DIFF
--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -1596,6 +1596,19 @@ def request_material(item_code, qty, reason=None, job_card: Optional[str] = None
         mr.notes = reason
     mr.flags.ignore_permissions = True
     mr.insert()
+
+    # Notify any live Storekeeper Hub sessions so they refresh their
+    # Pending Requests panel without polling. Listeners are scoped on the
+    # client side (only open Storekeeper Hubs react to the event).
+    try:
+        frappe.publish_realtime(
+            event="isnack_pending_mr_changed",
+            message={"mr": mr.name, "work_order": work_order, "item_code": item_code},
+            after_commit=True,
+        )
+    except Exception:
+        pass
+
     return {"ok": True, "mr": mr.name, "type": "Material Transfer"}
 
 @frappe.whitelist()

--- a/isnack/isnack/page/storekeeper_hub/storekeeper_hub.css
+++ b/isnack/isnack/page/storekeeper_hub/storekeeper_hub.css
@@ -851,3 +851,80 @@
 .po-receipt-dialog .po-row-batch-controls-anchor {
   display: contents;
 }
+
+/* =====================================
+   Pending Material Requests panel
+   ===================================== */
+.storekeeper-hub .pending-mrs-card{
+  border-left: 3px solid #f59e0b;       /* amber stripe — operator-flagged shortage */
+}
+.storekeeper-hub .pending-mrs-card h5{
+  color: #92400e;
+}
+.storekeeper-hub #pending-mr-count{
+  font-weight: 600;
+  color: #b45309;
+}
+
+.storekeeper-hub .pending-mrs .hub-row.pending-mr-row{
+  display: grid !important;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: .55rem;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line, #e3e8ee);
+  background: #fffbeb;                  /* very subtle amber so it stands out */
+  transition: background .12s ease;
+}
+.storekeeper-hub .pending-mrs .hub-row.pending-mr-row:hover{
+  background: #fef3c7;
+}
+.storekeeper-hub .pending-mrs .hub-row.pending-mr-row:last-child{
+  border-bottom: 0;
+}
+
+.storekeeper-hub .pending-mrs .pending-mr-main{
+  font-weight: 600;
+  line-height: 1.25;
+}
+.storekeeper-hub .pending-mrs .pending-mr-wo{
+  color: #1d4ed8;
+  text-decoration: underline dotted;
+  cursor: pointer;
+}
+.storekeeper-hub .pending-mrs .pending-mr-reason{
+  background: #fff3d6;
+  border: 1px solid #fde68a;
+  color: #78350f;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: .72rem;
+  font-weight: 600;
+  letter-spacing: .2px;
+}
+
+.storekeeper-hub .pending-mrs .pending-mr-qty{
+  white-space: nowrap;
+  text-align: right;
+}
+.storekeeper-hub .pending-mrs .pending-mr-qty b{
+  font-size: 1.05rem;
+}
+.storekeeper-hub .pending-mrs .xsmall{ font-size: .7rem; }
+
+/* Stage button — primary call-to-action on the row */
+.storekeeper-hub .pending-mrs .pending-mr-stage{
+  background: #15b79e;
+  border-color: #109487;
+  color: #ffffff;
+}
+.storekeeper-hub .pending-mrs .pending-mr-stage:hover{
+  background: #109487;
+  border-color: #0e7c70;
+  color: #ffffff;
+}
+.storekeeper-hub .pending-mrs .pending-mr-open{
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  color: #1f2937;
+}

--- a/isnack/isnack/page/storekeeper_hub/storekeeper_hub.html
+++ b/isnack/isnack/page/storekeeper_hub/storekeeper_hub.html
@@ -66,8 +66,19 @@
       </div>
     </div>
 
-    <!-- Right: Recently Staged + Pallet tracker -->
+    <!-- Right: Pending Requests + Recently Staged + Pallet tracker -->
     <div class="col col-right">
+      <div class="card pending-mrs-card">
+        <h5>
+          Pending Requests
+          <span class="muted small ms-1" id="pending-mr-count"></span>
+        </h5>
+        <div class="muted small mb-1">
+          Operator-initiated Material Requests for the selected line.
+          Click <b>Stage</b> to fulfil from the source warehouse.
+        </div>
+        <div class="list pending-mrs"></div>
+      </div>
       <div class="card">
         <h5>Staged (Production Date) <span class="muted" id="staged-date-label"></span></h5>
         <div class="list staged"></div>

--- a/isnack/isnack/page/storekeeper_hub/storekeeper_hub.js
+++ b/isnack/isnack/page/storekeeper_hub/storekeeper_hub.js
@@ -393,9 +393,21 @@ frappe.pages['storekeeper-hub'].on_page_load = function(wrapper) {
     load_staged();
     load_manual_entries();
     load_pallets();
+    load_pending_mrs();
   };
 
   refresh_btn.on('click', refresh);
+
+  // ----- Realtime: refresh Pending Requests when an operator creates an
+  // MR or when one is fulfilled. Listener is scoped to this page only -
+  // it is removed when the page is destroyed (next on_page_load) since
+  // the closure goes with it. ------------------------------------------
+  if (frappe.realtime && frappe.realtime.on) {
+    frappe.realtime.on('isnack_pending_mr_changed', () => {
+      // Only react if the page is still in the DOM.
+      if ($('.pending-mrs').length) load_pending_mrs();
+    });
+  }
 
   // --- Generate Picklist ---
   async function generate_picklist() {
@@ -945,6 +957,8 @@ frappe.pages['storekeeper-hub'].on_page_load = function(wrapper) {
   const $staged  = $hub.find('.staged');
   const $manual  = $hub.find('.manual-se');
   const $pallets = $hub.find('.pallets');
+  const $pendingMrs = $hub.find('.pending-mrs');
+  const $pendingMrCount = $('#pending-mr-count');
 
   // Visual cues for WO selection within a bucket
   function paint_selection($bucket) {
@@ -1788,6 +1802,151 @@ frappe.pages['storekeeper-hub'].on_page_load = function(wrapper) {
       `).find('.cell:last').append(open_btn).end());
     });
     if (!$pallets.children().length) $pallets.append('<div class="muted">No pallets in the last 24h</div>');
+  }
+
+  // ---------- Pending Material Requests ----------
+  async function load_pending_mrs(){
+    if (!$pendingMrs.length) return;
+    $pendingMrs.empty().append('<div class="muted">Loading…</div>');
+    let rows = [];
+    try {
+      const r = await frappe.call({
+        method: 'isnack.isnack.page.storekeeper_hub.storekeeper_hub.get_pending_material_requests',
+        args: { factory_line: state.factory_line || null }
+      });
+      rows = r.message || [];
+    } catch (e) {
+      $pendingMrs.empty().append('<div class="muted">Failed to load Material Requests.</div>');
+      $pendingMrCount.text('');
+      return;
+    }
+    $pendingMrs.empty();
+    $pendingMrCount.text(rows.length ? `(${rows.length})` : '');
+
+    if (!rows.length) {
+      $pendingMrs.append('<div class="muted">No pending requests for this line.</div>');
+      return;
+    }
+
+    rows.forEach(row => {
+      const $r = $(`
+        <div class="hub-row pending-mr-row" data-mr="${frappe.utils.escape_html(row.mr)}" data-mri="${frappe.utils.escape_html(row.mri)}">
+          <div class="cell">
+            <div class="pending-mr-main">
+              <b>${frappe.utils.escape_html(row.item_code)}</b>
+              <span class="muted">— ${frappe.utils.escape_html(row.item_name || '')}</span>
+            </div>
+            <div class="muted small">
+              WO <a class="pending-mr-wo">${frappe.utils.escape_html(row.work_order || '')}</a>
+              ${row.factory_line ? ` · Line ${frappe.utils.escape_html(row.factory_line)}` : ''}
+              ${row.reason ? ` · <span class="pending-mr-reason">${frappe.utils.escape_html(row.reason)}</span>` : ''}
+            </div>
+            <div class="muted small">
+              ${frappe.utils.escape_html(row.operator || '')}
+              · ${frappe.datetime.comment_when(row.creation)}
+            </div>
+          </div>
+          <div class="cell text-end pending-mr-qty">
+            <b>${fmt_qty(row.remaining)}</b>
+            <span class="muted small">${frappe.utils.escape_html(row.uom || '')}</span>
+            ${row.received > 0 ? `<div class="muted xsmall">of ${fmt_qty(row.requested)} requested</div>` : ''}
+          </div>
+          <div class="cell">
+            <div class="btn-group">
+              <button class="btn btn-xs btn-default pending-mr-open" title="Open Material Request">Open</button>
+              <button class="btn btn-xs btn-primary pending-mr-stage" title="Fulfil from Source Warehouse">Stage</button>
+            </div>
+          </div>
+        </div>
+      `);
+      $r.find('.pending-mr-open').on('click', () => frappe.set_route('Form', 'Material Request', row.mr));
+      $r.find('.pending-mr-wo').on('click', (ev) => {
+        ev.preventDefault(); ev.stopPropagation();
+        if (row.work_order) frappe.set_route('Form', 'Work Order', row.work_order);
+      });
+      $r.find('.pending-mr-stage').on('click', () => show_stage_mr_dialog(row));
+      $pendingMrs.append($r);
+    });
+  }
+
+  function show_stage_mr_dialog(row){
+    const default_src = state.src_warehouse || '';
+    const itemHasBatch = (row.item_code || '');
+
+    const d = new frappe.ui.Dialog({
+      title: __('Stage Material Request {0}', [row.mr]),
+      fields: [
+        {
+          fieldtype: 'HTML', fieldname: 'header',
+          options: `
+            <div class="mb-2">
+              <b>${frappe.utils.escape_html(row.item_code)}</b>
+              <span class="text-muted">— ${frappe.utils.escape_html(row.item_name || '')}</span>
+              <div class="text-muted small">
+                Requested ${fmt_qty(row.requested)} ${frappe.utils.escape_html(row.uom || '')}
+                · Already received ${fmt_qty(row.received)} ${frappe.utils.escape_html(row.uom || '')}
+                · Remaining <b>${fmt_qty(row.remaining)} ${frappe.utils.escape_html(row.uom || '')}</b>
+              </div>
+              ${row.reason ? `<div class="text-muted small mt-1">Reason: ${frappe.utils.escape_html(row.reason)}</div>` : ''}
+            </div>`
+        },
+        {
+          fieldtype: 'Link', fieldname: 'source_warehouse', options: 'Warehouse',
+          label: __('Source Warehouse'), reqd: 1, default: default_src
+        },
+        {
+          fieldtype: 'Float', fieldname: 'qty',
+          label: __('Qty ({0})', [row.uom || '']), reqd: 1, default: row.remaining,
+          description: __('Cannot exceed remaining {0} {1}', [fmt_qty(row.remaining), row.uom || ''])
+        },
+        {
+          fieldtype: 'Link', fieldname: 'batch_no', options: 'Batch',
+          label: __('Batch (if batch-tracked)'),
+          get_query: () => {
+            const wh = d.get_value('source_warehouse');
+            if (!wh) return { filters: { item: itemHasBatch } };
+            return {
+              query: 'isnack.isnack.page.storekeeper_hub.storekeeper_hub.batch_link_query',
+              filters: { item_code: itemHasBatch, warehouse: wh, non_expired: 1 }
+            };
+          }
+        }
+      ],
+      primary_action_label: __('Stage'),
+      primary_action: (v) => {
+        const qty = parseFloat(v.qty || 0);
+        if (qty <= 0) {
+          frappe.msgprint(__('Qty must be positive')); return;
+        }
+        if (qty - row.remaining > 1e-9) {
+          frappe.msgprint(__('Qty exceeds remaining {0} {1}', [fmt_qty(row.remaining), row.uom || ''])); return;
+        }
+        frappe.call({
+          method: 'isnack.isnack.page.storekeeper_hub.storekeeper_hub.fulfil_material_request',
+          args: {
+            material_request: row.mr,
+            material_request_item: row.mri,
+            source_warehouse: v.source_warehouse,
+            qty: qty,
+            batch_no: v.batch_no || null,
+          },
+          freeze: true,
+          freeze_message: __('Submitting Stock Entry…'),
+          callback: (r) => {
+            if (!r.message || !r.message.ok) return;
+            d.hide();
+            frappe.show_alert({
+              message: __('Staged: Stock Entry {0}', [r.message.stock_entry]),
+              indicator: 'green'
+            }, 5);
+            // refresh both panels
+            load_pending_mrs();
+            load_staged();
+          }
+        });
+      }
+    });
+    d.show();
   }
 
   // ---------- PO Receipt Dialog ----------

--- a/isnack/isnack/page/storekeeper_hub/storekeeper_hub.py
+++ b/isnack/isnack/page/storekeeper_hub/storekeeper_hub.py
@@ -1854,3 +1854,191 @@ def _normalize_batch_expiry_date(expiry_date=None, item_code=None, batch_no=None
                 expiry_text, item_code or _("Unknown"), batch_no or _("Unknown")
             )
         )
+
+
+# ============================================================================
+# Pending Material Requests (operator-initiated "Request More Material" flow)
+# ============================================================================
+
+def _mr_realtime_room() -> str:
+    """Channel name used to broadcast MR-related events to live Storekeeper Hubs."""
+    return "isnack_storekeeper_hub"
+
+
+@frappe.whitelist()
+def get_pending_material_requests(factory_line: str | None = None,
+                                  source_warehouse: str | None = None):
+    """List operator-initiated Material Requests still awaiting fulfilment.
+
+    Filters:
+      - material_request_type = 'Material Transfer'
+      - docstatus = 1 (submitted)
+      - status not in ('Stopped','Cancelled')
+      - linked to a Work Order whose status is not 'Completed'
+      - row-level remaining > 0
+      - optional factory_line (resolved via WO.custom_factory_line or BOM default)
+
+    Returns one row per *Material Request Item* with all the detail the
+    Storekeeper Hub needs to render and stage from a single click.
+    """
+    factory_line = _normalize_factory_line(factory_line)
+
+    rows = frappe.db.sql(
+        """
+        select
+            mr.name              as mr,
+            mr.work_order        as work_order,
+            wo.production_item   as production_item,
+            wo.item_name         as wo_item_name,
+            wo.custom_factory_line as wo_line,
+            bom.custom_default_factory_line as bom_line,
+            mr.transaction_date,
+            mr.creation,
+            mr.owner             as operator,
+            mr.notes             as reason,
+            mri.name             as mri,
+            mri.item_code,
+            mri.item_name,
+            mri.uom,
+            mri.qty              as requested_qty,
+            mri.received_qty,
+            mri.ordered_qty
+        from `tabMaterial Request` mr
+        join `tabMaterial Request Item` mri on mri.parent = mr.name
+        left join `tabWork Order` wo on wo.name = mr.work_order
+        left join `tabBOM` bom on bom.name = wo.bom_no
+        where mr.docstatus = 1
+          and mr.material_request_type = 'Material Transfer'
+          and mr.status not in ('Stopped','Cancelled')
+          and (wo.status is null or wo.status != 'Completed')
+        order by mr.creation desc
+        limit 200
+        """,
+        as_dict=True,
+    )
+
+    out = []
+    for r in rows:
+        line = r.get("wo_line") or r.get("bom_line") or None
+        if factory_line and line != factory_line:
+            continue
+        requested = float(r.get("requested_qty") or 0)
+        received = float(r.get("received_qty") or 0)
+        remaining = max(requested - received, 0)
+        if remaining <= 0:
+            continue
+        out.append({
+            "mr": r["mr"],
+            "mri": r["mri"],
+            "work_order": r.get("work_order"),
+            "wo_item_name": r.get("wo_item_name"),
+            "production_item": r.get("production_item"),
+            "factory_line": line,
+            "transaction_date": r.get("transaction_date"),
+            "creation": r.get("creation"),
+            "operator": r.get("operator"),
+            "reason": r.get("reason"),
+            "item_code": r.get("item_code"),
+            "item_name": r.get("item_name"),
+            "uom": r.get("uom"),
+            "requested": requested,
+            "received": received,
+            "remaining": remaining,
+        })
+    return out
+
+
+@frappe.whitelist()
+def fulfil_material_request(material_request: str,
+                            material_request_item: str,
+                            source_warehouse: str,
+                            qty: float,
+                            batch_no: str | None = None):
+    """Stage an operator's Material Request by creating and submitting a
+    Material Transfer Stock Entry from `source_warehouse` to the WO's
+    staging-or-WIP warehouse. Setting `material_request` and
+    `material_request_item` on the detail row makes ERPNext auto-update
+    the MR's received quantity, eventually marking it Transferred.
+    """
+    if not material_request:
+        frappe.throw(_("Missing Material Request"))
+    if not material_request_item:
+        frappe.throw(_("Missing Material Request Item"))
+    if not source_warehouse:
+        frappe.throw(_("Source Warehouse is required"))
+
+    qty = float(qty or 0)
+    if qty <= 0:
+        frappe.throw(_("Qty must be positive"))
+
+    mr = frappe.get_doc("Material Request", material_request)
+    if mr.docstatus != 1:
+        frappe.throw(_("Material Request {0} is not submitted").format(mr.name))
+    if mr.status in ("Stopped", "Cancelled"):
+        frappe.throw(_("Material Request {0} is {1}").format(mr.name, mr.status))
+    if mr.material_request_type != "Material Transfer":
+        frappe.throw(_("Only Material Transfer Material Requests can be staged here"))
+    if not mr.work_order:
+        frappe.throw(_("Material Request {0} is not linked to a Work Order").format(mr.name))
+
+    mri = next((r for r in mr.items if r.name == material_request_item), None)
+    if not mri:
+        frappe.throw(_("Material Request Item {0} not found on {1}").format(
+            material_request_item, mr.name))
+
+    requested = float(mri.qty or 0)
+    already = float(mri.received_qty or 0)
+    remaining = max(requested - already, 0)
+    if remaining <= 0:
+        frappe.throw(_("This request line is already fulfilled."))
+    if qty - remaining > 1e-9:
+        frappe.throw(_("Qty {0} exceeds remaining {1} {2}").format(
+            qty, remaining, mri.uom or ""))
+
+    # Resolve target warehouse: prefer staging, fall back to WIP. Mirrors the
+    # logic used by `create_consolidated_transfers`.
+    wo_doc = frappe.get_doc("Work Order", mr.work_order)
+    target_wh = _staging_for(wo_doc) or _wip_for(wo_doc)
+    if not target_wh:
+        frappe.throw(_("No Staging or WIP warehouse configured for WO {0}").format(wo_doc.name))
+
+    # Batch validation: required if the item is batch-tracked.
+    item_has_batch = bool(frappe.db.get_value("Item", mri.item_code, "has_batch_no"))
+    batch_no = (batch_no or "").strip() or None
+    if item_has_batch and not batch_no:
+        frappe.throw(_("Batch is required for item {0}").format(mri.item_code))
+
+    se = frappe.new_doc("Stock Entry")
+    se.company = wo_doc.company
+    se.stock_entry_type = "Material Transfer"
+    se.purpose = "Material Transfer"
+    se.work_order = wo_doc.name
+    se.from_warehouse = source_warehouse
+    se.to_warehouse = target_wh
+    se.remarks = _("Fulfil Material Request {0} | WO: {1}").format(mr.name, wo_doc.name)
+    se.append("items", {
+        "item_code": mri.item_code,
+        "qty": flt(qty, 3),
+        "uom": mri.uom or frappe.db.get_value("Item", mri.item_code, "stock_uom"),
+        "s_warehouse": source_warehouse,
+        "t_warehouse": target_wh,
+        "batch_no": batch_no,
+        "use_serial_batch_fields": 1 if batch_no else 0,
+        # Linking to MR makes ERPNext update mri.received_qty and the MR status.
+        "material_request": mr.name,
+        "material_request_item": mri.name,
+    })
+    se.insert(ignore_permissions=True)
+    se.submit()
+
+    # Notify any open Storekeeper Hubs so they can refresh.
+    try:
+        frappe.publish_realtime(
+            event="isnack_pending_mr_changed",
+            message={"mr": mr.name, "stock_entry": se.name},
+            after_commit=True,
+        )
+    except Exception:
+        pass
+
+    return {"ok": True, "stock_entry": se.name, "mr": mr.name}


### PR DESCRIPTION
The Storekeeper Hub gains a "Pending Requests" panel in the right column that lists every operator-initiated Material Request still awaiting fulfilment, scoped to the storekeeper's selected line. Each row shows the item, the WO, the requested vs remaining qty, the operator's reason and a one-click Stage button that fulfils the request.

Stage opens a dialog (source warehouse, qty, batch picker filtered to the source warehouse via batch_link_query) and, on confirm, creates and submits a Material Transfer Stock Entry from source to the WO's staging-or-WIP warehouse. Each detail row carries the standard `material_request` and `material_request_item` references so ERPNext auto-updates the MR's received qty and eventually marks it Transferred without any manual reconciliation.

The panel auto-refreshes via a realtime event:
  - mes_ops.request_material publishes `isnack_pending_mr_changed` after committing the MR
  - fulfil_material_request publishes the same event after the SE submits
  - The Storekeeper Hub subscribes for the lifetime of the page

Backend additions in storekeeper_hub.py:
  - get_pending_material_requests(factory_line=None) returns one row per Material Request Item with derived remaining = qty - received, filtered to Material Transfer MRs whose Work Order is not Completed. Line filter resolves via WO.custom_factory_line or the BOM default.
  - fulfil_material_request(material_request, material_request_item, source_warehouse, qty, batch_no=None) validates qty against the MR remaining, batch presence for batch-tracked items, and delegates target warehouse selection to _staging_for/_wip_for (mirroring create_consolidated_transfers).

Closes the Operator-Hub <-> Storekeeper-Hub loop for "Request More Material" - operator requests now physically appear on the storekeeper kiosk instead of being lost in the standard Material Request list.

https://claude.ai/code/session_01Rx8ZtmyzgCJ5q712g3SpDc