### PR TITLE
Storekeeper Hub: stack Pending Requests row for narrow column

### DIFF
--- a/isnack/isnack/page/storekeeper_hub/storekeeper_hub.css
+++ b/isnack/isnack/page/storekeeper_hub/storekeeper_hub.css
@@ -867,10 +867,7 @@
 }
 
 .storekeeper-hub .pending-mrs .hub-row.pending-mr-row{
-  display: grid !important;
-  grid-template-columns: 1fr auto auto;
-  align-items: center;
-  gap: .55rem;
+  display: block !important;            /* match staged/pallets pattern - narrow column friendly */
   padding: 10px 12px;
   border-bottom: 1px solid var(--line, #e3e8ee);
   background: #fffbeb;                  /* very subtle amber so it stands out */
@@ -883,9 +880,36 @@
   border-bottom: 0;
 }
 
-.storekeeper-hub .pending-mrs .pending-mr-main{
+/* Top strip: item + remaining qty on the right */
+.storekeeper-hub .pending-mrs .pending-mr-head{
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: .5rem;
+  margin-bottom: 4px;
+}
+.storekeeper-hub .pending-mrs .pending-mr-id{
   font-weight: 600;
   line-height: 1.25;
+  flex: 1 1 auto;
+  min-width: 0;
+  word-break: break-word;
+}
+.storekeeper-hub .pending-mrs .pending-mr-qty{
+  white-space: nowrap;
+  text-align: right;
+  flex: 0 0 auto;
+}
+.storekeeper-hub .pending-mrs .pending-mr-qty b{
+  font-size: 1.05rem;
+  color: #92400e;
+}
+
+/* Middle strip: WO link, line, reason chip */
+.storekeeper-hub .pending-mrs .pending-mr-meta{
+  margin-bottom: 6px;
+  word-break: break-word;
+  line-height: 1.3;
 }
 .storekeeper-hub .pending-mrs .pending-mr-wo{
   color: #1d4ed8;
@@ -893,6 +917,7 @@
   cursor: pointer;
 }
 .storekeeper-hub .pending-mrs .pending-mr-reason{
+  display: inline-block;
   background: #fff3d6;
   border: 1px solid #fde68a;
   color: #78350f;
@@ -901,16 +926,22 @@
   font-size: .72rem;
   font-weight: 600;
   letter-spacing: .2px;
+  margin-left: 2px;
+  vertical-align: baseline;
 }
 
-.storekeeper-hub .pending-mrs .pending-mr-qty{
-  white-space: nowrap;
-  text-align: right;
+/* Bottom strip: operator + actions, side by side */
+.storekeeper-hub .pending-mrs .pending-mr-foot{
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: .5rem;
+  flex-wrap: wrap;
 }
-.storekeeper-hub .pending-mrs .pending-mr-qty b{
-  font-size: 1.05rem;
+.storekeeper-hub .pending-mrs .pending-mr-foot .btn-group{
+  flex: 0 0 auto;
 }
-.storekeeper-hub .pending-mrs .xsmall{ font-size: .7rem; }
+.storekeeper-hub .pending-mrs .xsmall{ font-size: .72rem; }
 
 /* Stage button — primary call-to-action on the row */
 .storekeeper-hub .pending-mrs .pending-mr-stage{

--- a/isnack/isnack/page/storekeeper_hub/storekeeper_hub.js
+++ b/isnack/isnack/page/storekeeper_hub/storekeeper_hub.js
@@ -1829,29 +1829,30 @@ frappe.pages['storekeeper-hub'].on_page_load = function(wrapper) {
     }
 
     rows.forEach(row => {
+      const partial = row.received > 0
+        ? `<span class="muted xsmall">(of ${fmt_qty(row.requested)})</span>`
+        : '';
       const $r = $(`
         <div class="hub-row pending-mr-row" data-mr="${frappe.utils.escape_html(row.mr)}" data-mri="${frappe.utils.escape_html(row.mri)}">
-          <div class="cell">
-            <div class="pending-mr-main">
+          <div class="pending-mr-head">
+            <div class="pending-mr-id">
               <b>${frappe.utils.escape_html(row.item_code)}</b>
               <span class="muted">— ${frappe.utils.escape_html(row.item_name || '')}</span>
             </div>
-            <div class="muted small">
-              WO <a class="pending-mr-wo">${frappe.utils.escape_html(row.work_order || '')}</a>
-              ${row.factory_line ? ` · Line ${frappe.utils.escape_html(row.factory_line)}` : ''}
-              ${row.reason ? ` · <span class="pending-mr-reason">${frappe.utils.escape_html(row.reason)}</span>` : ''}
-            </div>
-            <div class="muted small">
-              ${frappe.utils.escape_html(row.operator || '')}
-              · ${frappe.datetime.comment_when(row.creation)}
+            <div class="pending-mr-qty">
+              <b>${fmt_qty(row.remaining)}</b>
+              <span class="muted small">${frappe.utils.escape_html(row.uom || '')}</span>
+              ${partial}
             </div>
           </div>
-          <div class="cell text-end pending-mr-qty">
-            <b>${fmt_qty(row.remaining)}</b>
-            <span class="muted small">${frappe.utils.escape_html(row.uom || '')}</span>
-            ${row.received > 0 ? `<div class="muted xsmall">of ${fmt_qty(row.requested)} requested</div>` : ''}
+          <div class="pending-mr-meta muted small">
+            WO <a class="pending-mr-wo">${frappe.utils.escape_html(row.work_order || '')}</a>${row.factory_line ? ` · Line ${frappe.utils.escape_html(row.factory_line)}` : ''}
+            ${row.reason ? ` <span class="pending-mr-reason">${frappe.utils.escape_html(row.reason)}</span>` : ''}
           </div>
-          <div class="cell">
+          <div class="pending-mr-foot">
+            <div class="muted xsmall">
+              ${frappe.utils.escape_html(row.operator || '')} · ${frappe.datetime.comment_when(row.creation)}
+            </div>
             <div class="btn-group">
               <button class="btn btn-xs btn-default pending-mr-open" title="Open Material Request">Open</button>
               <button class="btn btn-xs btn-primary pending-mr-stage" title="Fulfil from Source Warehouse">Stage</button>


### PR DESCRIPTION
The first revision used a 3-column grid (1fr auto auto) which got squeezed inside the right column - the info ended up wrapping into a tall stack against a centred qty + buttons cell, which read badly.

Restructure each row into three vertical strips, matching the display:block pattern already used by the Staged and Pallet panels:
  - head: item code + name on the left, remaining qty on the right
  - meta: WO link, line, reason chip
  - foot: operator + time-ago on the left, Open + Stage on the right

Also tightens the reason chip (inline-block, vertical-align baseline) and gives the qty number an amber tint so it reads as the primary value in the row at a glance.

https://claude.ai/code/session_01Rx8ZtmyzgCJ5q712g3SpDc