### PR TITLE
Add label combining feature to operator hub

### DIFF
--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -3128,7 +3128,10 @@ def list_label_records(work_order: str):
     if not frappe.db.exists("DocType", "Label Record"):
         return []
 
-    # Query via child table to find labels linked to ANY of the work orders
+    # Query via child table to find labels linked to ANY of the work orders.
+    # Source rows tagged 'combined-into:%' represent labels that were merged
+    # into an aggregate record; skip them so operators can't re-select an
+    # already-consumed original (which would double-count its quantity).
     records = frappe.db.sql("""
         SELECT DISTINCT
             lr.name,
@@ -3142,6 +3145,9 @@ def list_label_records(work_order: str):
         INNER JOIN `tabLabel Record Source` lrs ON lrs.parent = lr.name
         WHERE lrs.source_doctype = 'Work Order'
             AND lrs.source_docname = %(work_order)s
+            AND (lrs.source_status IS NULL
+                 OR lrs.source_status = ''
+                 OR lrs.source_status NOT LIKE 'combined-into:%%')
         ORDER BY lr.creation DESC
         LIMIT 20
     """, {"work_order": work_order}, as_dict=True)
@@ -3373,11 +3379,26 @@ def combine_label_records(label_records, reason_code: Optional[str] = None, prin
             combined.append("sources", {
                 "source_doctype": src.source_doctype,
                 "source_docname": src.source_docname,
-                "source_status": getattr(src, "source_status", None),
             })
 
     combined.flags.ignore_permissions = True
     combined.insert()
+
+    # Mark every source row on the inputs as consumed by this combine so they
+    # stop appearing in Label History — otherwise an operator could pick an
+    # original plus the aggregate and double-count the original's quantity.
+    consumed_marker = f"combined-into:{combined.name}"
+    for rec in records:
+        for src in (rec.sources or []):
+            if not src.name:
+                continue
+            frappe.db.set_value(
+                "Label Record Source",
+                src.name,
+                "source_status",
+                consumed_marker,
+                update_modified=False,
+            )
 
     fs = _fs()
     target_printer = printer or getattr(fs, "default_label_printer", None)
@@ -3385,6 +3406,19 @@ def combine_label_records(label_records, reason_code: Optional[str] = None, prin
     first_source = combined.sources[0] if combined.sources else None
     source_doctype = first_source.source_doctype if first_source else None
     source_docname = first_source.source_docname if first_source else None
+
+    # Detect label flavor from the inputs' payload so we pass the same quantity
+    # query parameter the originating print path used (carton_qty vs pallet_qty),
+    # which is the only quantity the print format actually receives.
+    is_pallet_label = False
+    pallet_type = None
+    try:
+        first_payload = json.loads(first.payload) if first.payload else {}
+        if isinstance(first_payload, dict) and first_payload.get("pallet_type"):
+            is_pallet_label = True
+            pallet_type = first_payload.get("pallet_type")
+    except (TypeError, ValueError):
+        pass
 
     jobs = []
     print_urls = []
@@ -3398,11 +3432,16 @@ def combine_label_records(label_records, reason_code: Optional[str] = None, prin
         ))
 
     if source_doctype and source_docname:
-        print_urls.append(_generate_print_url(
+        url = _generate_print_url(
             source_doctype,
             source_docname,
             combined.label_template,
-        ))
+        )
+        if is_pallet_label:
+            url = f"{url}&pallet_qty={total_qty}&pallet_type={frappe.utils.quote(pallet_type or '')}"
+        else:
+            url = f"{url}&carton_qty={total_qty}"
+        print_urls.append(url)
 
     enable_silent_printing = getattr(fs, "enable_silent_printing", False)
 

--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -3274,6 +3274,152 @@ def print_label_record(label_record: str, printer: Optional[str] = None, quantit
         "printer_name": target_printer
     }
 
+
+@frappe.whitelist()
+def combine_label_records(label_records, reason_code: Optional[str] = None, printer: Optional[str] = None):
+    """
+    Combine two or more Label Records into a single aggregated Label Record and
+    return a print URL for the merged label. Mirrors the Split flow in reverse:
+    Split keeps one record and prints N copies; Combine takes N records and
+    produces one new record with the summed quantity.
+
+    All input records must share the same item_code, label_template and batch_no.
+    The new record's `sources` child table is the deduplicated union of the
+    inputs' sources, so the combined label appears in Label History for every
+    Work Order that fed into it.
+
+    Args:
+        label_records: List (or JSON string) of Label Record names to combine.
+        reason_code:   Audit reason recorded on the new Label Print Job
+                       (defaults to 'combine').
+        printer:       Optional printer override for the Print Job audit row.
+
+    Returns:
+        dict with the same shape as print_label_record so the client can reuse
+        its print-handling code: label_record, jobs, print_urls, doctype,
+        docname, print_format, enable_silent_printing, printer_name, and the
+        list of combined source record names.
+    """
+    _require_roles(ROLES_OPERATOR)
+
+    if not frappe.db.exists("DocType", "Label Record"):
+        frappe.throw(_("Label Record is not enabled."))
+
+    raw_names = label_records
+    if isinstance(raw_names, str):
+        raw_names = json.loads(raw_names)
+    if not isinstance(raw_names, (list, tuple)):
+        frappe.throw(_("label_records must be a list of Label Record names."))
+
+    # Preserve order while removing duplicates
+    seen = set()
+    names = []
+    for n in raw_names:
+        if not n or n in seen:
+            continue
+        seen.add(n)
+        names.append(n)
+
+    if len(names) < 2:
+        frappe.throw(_("Select at least two Label Records to combine."))
+
+    records = [frappe.get_doc("Label Record", n) for n in names]
+
+    first = records[0]
+    for rec in records[1:]:
+        if (rec.item_code or "") != (first.item_code or ""):
+            frappe.throw(_("All selected labels must be for the same Item (got {0} and {1}).")
+                         .format(first.item_code, rec.item_code))
+        if (rec.label_template or "") != (first.label_template or ""):
+            frappe.throw(_("All selected labels must use the same Label Template (got {0} and {1}).")
+                         .format(first.label_template, rec.label_template))
+        if (rec.batch_no or "") != (first.batch_no or ""):
+            frappe.throw(_("All selected labels must share the same Batch (got {0} and {1}).")
+                         .format(first.batch_no or "-", rec.batch_no or "-"))
+
+    total_qty = sum(flt(rec.quantity) for rec in records)
+    if total_qty <= 0:
+        frappe.throw(_("Combined quantity must be greater than zero."))
+
+    is_print_format = frappe.db.exists("Print Format", first.label_template)
+
+    combined = frappe.new_doc("Label Record")
+    combined.label_template = first.label_template
+    combined.template_engine = first.template_engine or ("Jinja" if is_print_format else "Template")
+
+    payload_info = {
+        "combined_from": names,
+        "original_quantities": [flt(rec.quantity) for rec in records],
+        "reason_code": reason_code or "combine",
+    }
+    combined.payload = json.dumps(payload_info)
+    combined.payload_hash = hashlib.sha256(
+        f"combine_{first.label_template}_{first.item_code}_{first.batch_no or ''}_{total_qty}_{'|'.join(names)}".encode("utf-8")
+    ).hexdigest()
+
+    combined.quantity = total_qty
+    combined.item_code = first.item_code
+    combined.item_name = first.item_name
+    combined.batch_no = first.batch_no
+
+    # Union the source documents from every input record, preserving order
+    seen_sources = set()
+    for rec in records:
+        for src in (rec.sources or []):
+            key = (src.source_doctype, src.source_docname)
+            if not src.source_doctype or not src.source_docname or key in seen_sources:
+                continue
+            seen_sources.add(key)
+            combined.append("sources", {
+                "source_doctype": src.source_doctype,
+                "source_docname": src.source_docname,
+                "source_status": getattr(src, "source_status", None),
+            })
+
+    combined.flags.ignore_permissions = True
+    combined.insert()
+
+    fs = _fs()
+    target_printer = printer or getattr(fs, "default_label_printer", None)
+
+    first_source = combined.sources[0] if combined.sources else None
+    source_doctype = first_source.source_doctype if first_source else None
+    source_docname = first_source.source_docname if first_source else None
+
+    jobs = []
+    print_urls = []
+
+    if target_printer:
+        jobs.append(_create_label_print_job(
+            combined,
+            target_printer,
+            total_qty,
+            reason_code=reason_code or "combine",
+        ))
+
+    if source_doctype and source_docname:
+        print_urls.append(_generate_print_url(
+            source_doctype,
+            source_docname,
+            combined.label_template,
+        ))
+
+    enable_silent_printing = getattr(fs, "enable_silent_printing", False)
+
+    return {
+        "label_record": combined.name,
+        "combined_from": names,
+        "combined_quantity": total_qty,
+        "jobs": [job.name for job in jobs if job],
+        "print_urls": print_urls,
+        "doctype": source_doctype,
+        "docname": source_docname,
+        "print_format": combined.label_template,
+        "enable_silent_printing": enable_silent_printing,
+        "printer_name": target_printer,
+    }
+
+
 # ============================================================
 # Small helpers used by UI (replace client get_list)
 # ============================================================

--- a/isnack/isnack/page/operator_hub/operator_hub.js
+++ b/isnack/isnack/page/operator_hub/operator_hub.js
@@ -1649,36 +1649,53 @@ function init_operator_hub($root) {
     const $box = d.fields_dict.labels_html.$wrapper;
     $box.html('<div class="text-muted">Loading labels…</div>');
 
-    try {
+    const rowsByName = new Map();
+
+    async function reloadHistory() {
+      $box.html('<div class="text-muted">Loading labels…</div>');
       const resp = await rpc('isnack.api.mes_ops.list_label_records', { work_order: state.current_wo });
       const rows = (resp && resp.message) || [];
+      rowsByName.clear();
+      rows.forEach((row) => rowsByName.set(row.name, row));
+
       if (!rows.length) {
         $box.html('<div class="text-muted">No labels recorded for this Work Order yet.</div>');
         return;
       }
 
-      const table = $(`
-        <div class="table-responsive">
-          <table class="table table-sm table-bordered">
-            <thead>
-              <tr>
-                <th>Label</th>
-                <th>Qty</th>
-                <th>Item</th>
-                <th>Batch</th>
-                <th>Template</th>
-                <th>Created</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-          </table>
+      const container = $(`
+        <div>
+          <div class="d-flex align-items-center mb-2 lr-toolbar">
+            <button class="btn btn-sm btn-primary" data-action="combine" disabled>Combine Selected (0)</button>
+            <span class="text-muted small ms-2">Tick two or more rows that share Item, Batch and Template.</span>
+          </div>
+          <div class="table-responsive">
+            <table class="table table-sm table-bordered">
+              <thead>
+                <tr>
+                  <th style="width:30px;"><input type="checkbox" data-action="select-all" /></th>
+                  <th>Label</th>
+                  <th>Qty</th>
+                  <th>Item</th>
+                  <th>Batch</th>
+                  <th>Template</th>
+                  <th>Created</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
         </div>
       `);
-      const $tbody = table.find('tbody');
+      const $tbody = container.find('tbody');
+      const $combineBtn = container.find('button[data-action="combine"]');
+      const $selectAll = container.find('input[data-action="select-all"]');
+
       rows.forEach((row) => {
         const $tr = $(`
           <tr>
+            <td><input type="checkbox" data-action="select-row" /></td>
             <td>${frappe.utils.escape_html(row.name)}</td>
             <td>${row.quantity ?? ''}</td>
             <td>${frappe.utils.escape_html(row.item_code || '')}</td>
@@ -1694,7 +1711,98 @@ function init_operator_hub($root) {
         $tr.data('row', row);
         $tbody.append($tr);
       });
-      $box.html(table);
+      $box.html(container);
+
+      function getSelectedRows() {
+        return $tbody.find('input[data-action="select-row"]:checked')
+          .map((_, el) => $(el).closest('tr').data('row'))
+          .get();
+      }
+
+      function refreshCombineState() {
+        const selected = getSelectedRows();
+        $combineBtn.text(`Combine Selected (${selected.length})`);
+        $combineBtn.prop('disabled', selected.length < 2);
+        const total = $tbody.find('input[data-action="select-row"]').length;
+        $selectAll.prop('checked', total > 0 && selected.length === total);
+      }
+
+      $tbody.on('change', 'input[data-action="select-row"]', refreshCombineState);
+      $selectAll.on('change', (e) => {
+        const checked = e.currentTarget.checked;
+        $tbody.find('input[data-action="select-row"]').prop('checked', checked);
+        refreshCombineState();
+      });
+
+      $combineBtn.on('click', async () => {
+        const selected = getSelectedRows();
+        if (selected.length < 2) return;
+
+        // Client-side guard so we surface mismatch errors before the RPC round-trip.
+        const first = selected[0];
+        const mismatch = selected.find(r =>
+          (r.item_code || '') !== (first.item_code || '') ||
+          (r.batch_no || '') !== (first.batch_no || '') ||
+          (r.label_template || '') !== (first.label_template || '')
+        );
+        if (mismatch) {
+          frappe.msgprint('Selected labels must share the same Item, Batch and Template.');
+          return;
+        }
+
+        const totalQty = selected.reduce((acc, r) => acc + (parseFloat(r.quantity) || 0), 0);
+        const namesHtml = selected
+          .map(r => `<li>${frappe.utils.escape_html(r.name)} — qty ${r.quantity ?? 0}</li>`)
+          .join('');
+
+        const combineDialog = opDialog({
+          title: `Combine ${selected.length} Labels`,
+          fields: [
+            { fieldtype: 'HTML', fieldname: 'preview',
+              options: `<div class="small">
+                          <div><b>Item:</b> ${frappe.utils.escape_html(first.item_code || '')}</div>
+                          <div><b>Batch:</b> ${frappe.utils.escape_html(first.batch_no || '-')}</div>
+                          <div><b>Template:</b> ${frappe.utils.escape_html(first.label_template || '')}</div>
+                          <div><b>Combined Qty:</b> ${totalQty}</div>
+                          <div class="mt-2"><b>Sources:</b><ul class="mb-0">${namesHtml}</ul></div>
+                        </div>` },
+            { label: 'Reason', fieldname: 'reason', fieldtype: 'Data', default: 'combine' }
+          ],
+          primary_action_label: 'Combine & Print',
+          primary_action: async (v) => {
+            setStatus('Combining labels…');
+            const result = await rpc('isnack.api.mes_ops.combine_label_records', {
+              label_records: selected.map(r => r.name),
+              reason_code: v.reason || 'combine'
+            });
+            combineDialog.hide();
+            const msg = result && result.message;
+            if (msg && msg.print_urls && msg.print_urls.length > 0) {
+              const enableSilent = msg.enable_silent_printing;
+              const printerName = msg.printer_name;
+              for (let idx = 0; idx < msg.print_urls.length; idx++) {
+                const url = msg.print_urls[idx];
+                if (idx > 0) {
+                  await new Promise(resolve => setTimeout(resolve, PRINT_DIALOG_DELAY_MS));
+                }
+                await handleLabelPrint(url, enableSilent, printerName, `${msg.label_record} combined ${idx + 1}`);
+              }
+              const action = enableSilent ? 'sent to printer' : 'dialog(s) opened';
+              frappe.show_alert({
+                message: `Combined label ${msg.label_record} (${msg.combined_quantity}) ${action}`,
+                indicator: 'green'
+              });
+            } else if (msg && msg.label_record) {
+              frappe.show_alert({
+                message: `Combined label ${msg.label_record} created (no printer configured).`,
+                indicator: 'orange'
+              });
+            }
+            await reloadHistory();
+          }
+        });
+        combineDialog.show();
+      });
 
       $tbody.on('click', 'button[data-action]', async (e) => {
         const $btn = $(e.currentTarget);
@@ -1789,6 +1897,10 @@ function init_operator_hub($root) {
           splitDialog.show();
         }
       });
+    }
+
+    try {
+      await reloadHistory();
     } catch (e) {
       console.error(e);
       $box.html('<div class="text-danger">Failed to load label history.</div>');
@@ -1805,7 +1917,7 @@ function init_operator_hub($root) {
     await showPrintLabelDialog();
   });
 
-  // Label History — list, reprint, and split labels tied to current Work Order
+  // Label History — list, reprint, split, and combine labels tied to current Work Order
   $('#btn-label-history',$root).on('click', async () => {
     if (!state.current_wo || !state.current_emp || !state.current_is_fg) return;
     await showLabelHistoryDialog();


### PR DESCRIPTION
## Summary
This PR adds the ability to combine multiple label records into a single aggregated label record in the Operator Hub. Users can now select two or more labels that share the same item, batch, and template, and merge them into one label with the combined quantity.

## Key Changes

**Frontend (operator_hub.js):**
- Refactored label history loading into a reusable `reloadHistory()` async function to support refreshing after combine operations
- Added checkbox selection UI to the label history table with "select all" functionality
- Implemented "Combine Selected" button that:
  - Validates selected labels share the same item, batch, and template
  - Opens a confirmation dialog showing the combined details and source labels
  - Calls the new backend combine API
  - Handles print job responses (silent or dialog-based printing)
  - Refreshes the label history after successful combine
- Added client-side validation before RPC call to surface mismatch errors early
- Updated comment to reflect new combine capability

**Backend (mes_ops.py):**
- Implemented new `combine_label_records()` RPC endpoint that:
  - Accepts a list of label record names to combine
  - Validates all records share the same item_code, label_template, and batch_no
  - Creates a new Label Record with summed quantity
  - Deduplicates and unions source documents from all input records so the combined label appears in history for every contributing Work Order
  - Records audit metadata (combined_from, original_quantities, reason_code) in the payload
  - Generates a print URL and creates a print job if a printer is configured
  - Returns response in the same format as `print_label_record()` for client code reuse

## Notable Implementation Details
- The combine operation mirrors the split flow in reverse: split keeps one record and prints N copies; combine takes N records and produces one new record
- Source document deduplication ensures the combined label is properly linked to all contributing Work Orders
- Audit trail is maintained via the payload JSON and print job reason codes
- Client-side validation prevents unnecessary RPC calls for mismatched selections
- Print handling reuses existing infrastructure for consistency

https://claude.ai/code/session_018vSKaRf88rm7xcJwwzQeRx