### PR TITLE
Fix TypeError when batch_no is not a string in Allocate & Transfer

### DIFF
--- a/isnack/isnack/page/storekeeper_hub/storekeeper_hub.js
+++ b/isnack/isnack/page/storekeeper_hub/storekeeper_hub.js
@@ -1579,7 +1579,7 @@ frappe.pages['storekeeper-hub'].on_page_load = function(wrapper) {
       if (!row.has_batch_no) return false;
       // Item requires batch but has neither single batch nor multi-batch assigned
       const has_batches = row.batches && row.batches.length > 0;
-      const has_single_batch = row.batch_no && row.batch_no.trim();
+      const has_single_batch = row.batch_no && String(row.batch_no).trim();
       return !has_batches && !has_single_batch;
     });
     


### PR DESCRIPTION
Coerce batch_no to a string before calling .trim(), since numeric batch codes were causing "row.batch_no.trim is not a function" in the cart validation.