### PR TITLE
fix: handle numeric batch codes in Storekeeper Hub allocate

### DIFF
--- a/isnack/isnack/page/storekeeper_hub/storekeeper_hub.js
+++ b/isnack/isnack/page/storekeeper_hub/storekeeper_hub.js
@@ -1361,7 +1361,9 @@ frappe.pages['storekeeper-hub'].on_page_load = function(wrapper) {
             let total_assigned = 0;
 
             d.$wrapper.find('#batch-selection-table .batch-row').each(function() {
-              const batch_no = $(this).data('batch');
+              // Use attr() not data(): jQuery's .data() coerces a purely
+              // numeric batch code into a Number, which later breaks .trim().
+              const batch_no = $(this).attr('data-batch');
               const qty_input = $(this).find('.batch-qty-input');
               const qty = parseFloat(qty_input.val() || 0);
               


### PR DESCRIPTION
jQuery's .data('batch') coerces a purely numeric batch code into a Number, so cart_row.batch_no became a number and the Allocate & Transfer batch-validation check threw "row.batch_no.trim is not a function". Read the attribute with .attr() to keep it a string.