### PR TITLE
Initialise manual price list rate via the price_list_rate event

### DIFF
--- a/isnack/public/js/sales_order_proforma.js
+++ b/isnack/public/js/sales_order_proforma.js
@@ -70,6 +70,27 @@ frappe.ui.form.on("Sales Order Item", {
 
             isnack_apply_manual_line_discount(frm, cdt, cdn, false);
         });
+    },
+
+    price_list_rate(frm, cdt, cdn) {
+        // ERPNext triggers this event after get_item_details / the item price
+        // lookup has populated the standard price_list_rate. Initialise the
+        // manual price list rate from it when the user has not set one yet,
+        // then let the user proceed with the normal manual flow.
+        const row = locals[cdt] && locals[cdt][cdn];
+        if (!row) {
+            return;
+        }
+
+        if (flt(row.price_list_rate) && !flt(row.custom_manual_price_list_rate)) {
+            row.custom_manual_price_list_rate = flt(
+                row.price_list_rate,
+                precision("custom_manual_price_list_rate", row)
+            );
+            frm.refresh_field("items");
+        }
+
+        isnack_apply_manual_line_discount(frm, cdt, cdn, false);
     }
 });
 


### PR DESCRIPTION
The item_code handler relied on frappe.after_ajax timing to read the fetched price_list_rate, which could run before ERPNext's async item price lookup populated it - leaving Manual Price List Rate at 0 for items that have an Item Price record.

Hook the price_list_rate event instead, which ERPNext explicitly triggers once get_item_details / the item price lookup has populated the standard rate, and initialise the manual price list rate from it.

https://claude.ai/code/session_01LWiSkYZdy6s4NpVULkSFs7