### PR TITLE
Move Operator Hub label buttons right of shift/close group

### DIFF
--- a/isnack/public/page/operator_hub/operator_hub.html
+++ b/isnack/public/page/operator_hub/operator_hub.html
@@ -127,18 +127,18 @@
 
         <div class="bar-sep" aria-hidden="true"></div>
 
-        <!-- Group 3: Labels -->
-        <div class="bar-group" aria-label="Labels">
-          <button id="btn-label" class="btn btn-lg tile-btn op-btn-label" disabled>Print Label</button>
-          <button id="btn-label-history" class="btn btn-lg tile-btn op-btn-label-outline" disabled>Label History</button>
+        <!-- Group 3: Shift return / Close production -->
+        <div class="bar-group" aria-label="Shift return or close production">
+          <button id="btn-end-shift-return" class="btn btn-lg tile-btn op-btn-material-outline">End Shift Return</button>
+          <button id="btn-close-production" class="btn btn-lg tile-btn op-btn-close-production">Close Production</button>
         </div>
 
         <div class="bar-sep" aria-hidden="true"></div>
 
-        <!-- Group 4: Shift return / Close production -->
-        <div class="bar-group" aria-label="Shift return or close production">
-          <button id="btn-end-shift-return" class="btn btn-lg tile-btn op-btn-material-outline">End Shift Return</button>
-          <button id="btn-close-production" class="btn btn-lg tile-btn op-btn-close-production">Close Production</button>
+        <!-- Group 4: Labels -->
+        <div class="bar-group" aria-label="Labels">
+          <button id="btn-label" class="btn btn-lg tile-btn op-btn-label" disabled>Print Label</button>
+          <button id="btn-label-history" class="btn btn-lg tile-btn op-btn-label-outline" disabled>Label History</button>
         </div>
 
       </div>


### PR DESCRIPTION
Swap the action bar groups so "Print Label" / "Label History" appear to the right of "End Shift Return" / "Close Production".

https://claude.ai/code/session_01LWiSkYZdy6s4NpVULkSFs7