### PR TITLE
Enforce operator locking for linked employees

### DIFF
--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -520,10 +520,18 @@ def _get_user_line(user: str) -> Optional[str]:
     return line or None
 
 def _user_employee(user: str) -> Optional[str]:
-    emp = frappe.db.get_value("Employee", {"user_id": user}, "name")
+    """Return the active Employee linked to a user, or None."""
+    if not user or user == "Guest":
+        return None
+    emp = frappe.db.get_value(
+        "Employee", {"user_id": user, "status": "Active"}, "name"
+    )
     if emp:
         return emp
-    return frappe.db.get_value("User", user, "employee")
+    fallback = frappe.db.get_value("User", user, "employee")
+    if fallback and frappe.db.get_value("Employee", fallback, "status") == "Active":
+        return fallback
+    return None
 
 def _employee_by_badge(badge: str) -> Optional[str]:
     if not badge:
@@ -537,9 +545,21 @@ def _employee_by_badge(badge: str) -> Optional[str]:
     return None
 
 def _employee_or_user_default(employee: Optional[str]) -> Optional[str]:
-    if employee:
-        return employee
-    return _user_employee(frappe.session.user)
+    """Resolve the operator for an Operator Hub action.
+
+    When the logged-in user is linked to an active Employee, that Employee
+    is authoritative: any conflicting client-supplied value is rejected.
+    This enforces the locked-operator rule server-side, so it does not rely
+    on the read-only behaviour of the front-end alone.
+    """
+    linked = _user_employee(frappe.session.user)
+    if linked:
+        if employee and employee != linked:
+            frappe.throw(
+                _("Your account is linked to Employee {0}; you cannot act as another operator.").format(linked)
+            )
+        return linked
+    return employee or None
 
 def _line_for_work_order(work_order: str) -> Optional[str]:
     """Prefer WO.factory_line/custom_factory_line, then BOM default, then first operation/workstation."""
@@ -823,6 +843,25 @@ def get_wo_banner(work_order):
 # ============================================================
 
 @frappe.whitelist()
+def get_operator_context():
+    """Operator binding for the current user.
+
+    When the logged-in user is linked to an active Employee, the Operator
+    Hub auto-selects that Employee and locks the Operator field. The same
+    binding is enforced server-side in `_employee_or_user_default`, so this
+    endpoint only drives the UI convenience.
+    """
+    emp = _user_employee(frappe.session.user)
+    if not emp:
+        return {"locked": False, "employee": None, "employee_name": None}
+    return {
+        "locked": True,
+        "employee": emp,
+        "employee_name": frappe.db.get_value("Employee", emp, "employee_name") or emp,
+    }
+
+
+@frappe.whitelist()
 def resolve_employee(badge: Optional[str] = None, employee: Optional[str] = None):
     emp = None
     if employee:
@@ -831,6 +870,11 @@ def resolve_employee(badge: Optional[str] = None, employee: Optional[str] = None
         emp = _employee_by_badge(badge)
     if not emp:
         return {"ok": False}
+    linked = _user_employee(frappe.session.user)
+    if linked and emp != linked:
+        frappe.throw(
+            _("Your account is linked to Employee {0}; you cannot select another operator.").format(linked)
+        )
     return {
         "ok": True,
         "employee": emp,

--- a/isnack/isnack/page/operator_hub/operator_hub.js
+++ b/isnack/isnack/page/operator_hub/operator_hub.js
@@ -242,6 +242,7 @@ function init_operator_hub($root) {
     current_lines: migrateLineStorage(),
     current_emp: null,
     current_emp_name: null,
+    operator_locked: false,
     current_is_fg: false,
     current_wo_status: null,
     current_stage_status: null
@@ -480,7 +481,11 @@ function init_operator_hub($root) {
 
   // Choose operator
   $('#kiosk-choose-emp', $root).on('click', () => {
-    setScanMode(false);  // avoid hidden scanner stealing focus inside dialog    
+    if (state.operator_locked) {
+      flashStatus('Operator is linked to your account and cannot be changed', 'warning');
+      return;
+    }
+    setScanMode(false);  // avoid hidden scanner stealing focus inside dialog
     const d = opDialog({
       title: 'Set Operator',
       fields: [
@@ -502,9 +507,41 @@ function init_operator_hub($root) {
   });
 
   $('#kiosk-clear-emp', $root).on('click', () => {
+    if (state.operator_locked) {
+      flashStatus('Operator is linked to your account and cannot be cleared', 'warning');
+      return;
+    }
     state.current_emp = null; state.current_emp_name = null;
     $('#kiosk-emp-label').text('—'); refreshButtonStates(); flashStatus('Operator cleared', 'warning');
   });
+
+  // Operator binding: if the logged-in user is linked to an active Employee,
+  // auto-set the Operator field to that Employee and make it read-only. The
+  // backend enforces the same rule, so this is only a UX convenience.
+  function applyOperatorLock(employee, employee_name) {
+    state.operator_locked = true;
+    state.current_emp = employee;
+    state.current_emp_name = employee_name;
+    $('#kiosk-emp-label', $root).text(employee_name);
+    $('#kiosk-choose-emp', $root)
+      .prop('disabled', true)
+      .attr('title', 'Operator is linked to your user account');
+    $('#kiosk-clear-emp', $root)
+      .prop('disabled', true)
+      .attr('title', 'Operator is linked to your user account');
+    refreshButtonStates();
+  }
+
+  (function loadOperatorContext() {
+    frappe.call('isnack.api.mes_ops.get_operator_context')
+      .then(r => {
+        const ctx = r && r.message;
+        if (ctx && ctx.locked && ctx.employee) {
+          applyOperatorLock(ctx.employee, ctx.employee_name || ctx.employee);
+        }
+      })
+      .catch(err => console.error('Failed to load operator context', err));
+  })();
 
   // === Materials snapshot ===
   function fmt(n){ return (n==null) ? '-' : (Math.round(n*1000)/1000).toLocaleString(); }


### PR DESCRIPTION
## Summary
This change implements server-side and client-side enforcement of operator locking when a user account is linked to an active Employee record. This prevents users from acting as a different operator, ensuring accountability in the manufacturing operations system.

## Key Changes

**Backend (`isnack/api/mes_ops.py`):**
- Enhanced `_user_employee()` to:
  - Return `None` for guest users
  - Only return active employees (filter by `status: "Active"`)
  - Validate fallback employee records are also active
  - Added docstring clarifying the function's purpose

- Updated `_employee_or_user_default()` to:
  - Check if the logged-in user is linked to an active employee
  - Throw an error if a conflicting employee is supplied by the client
  - Enforce the locked-operator rule server-side, independent of frontend behavior
  - Added comprehensive docstring explaining the authorization logic

- Added new `get_operator_context()` endpoint to:
  - Return operator binding information for the current user
  - Indicate whether the operator field should be locked
  - Provide employee name for UI display

- Updated `resolve_employee()` to:
  - Validate that selected employees match the user's linked employee
  - Throw an error if attempting to select a different operator

**Frontend (`isnack/isnack/page/operator_hub/operator_hub.js`):**
- Added `operator_locked` state flag to track operator binding status
- Modified operator selection button to:
  - Check lock status before opening dialog
  - Display warning message if locked
  - Prevent selection when operator is linked to account

- Modified operator clear button to:
  - Check lock status before clearing
  - Display warning message if locked
  - Prevent clearing when operator is linked to account

- Added `applyOperatorLock()` function to:
  - Auto-set the operator field to the linked employee
  - Disable both selection and clear buttons
  - Add tooltips explaining the lock

- Added `loadOperatorContext()` initialization to:
  - Call the new backend endpoint on page load
  - Apply operator lock if user is linked to an active employee

## Implementation Details
- The operator locking is enforced at both frontend (UX convenience) and backend (security), so the system doesn't rely solely on read-only UI behavior
- Only active employees are considered valid for operator binding
- Guest users and users without active employee links can still manually select operators (subject to backend validation)
- Error messages clearly explain why an operator cannot be changed or selected

https://claude.ai/code/session_016Tg92HRQqcbAtSFUn3Za4R