### PR TITLE
Refactor scan flow to confirm quantity before posting consumption

### DIFF
--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -723,6 +723,25 @@ def _has_recent_duplicate(work_order: str, raw_code: str, ttl_sec: Optional[int]
     cache.set_value(key, "1", expires_in_sec=ttl_sec or _scan_dup_ttl())
     return False
 
+def _scan_already_consumed(work_order: str, raw_code: str) -> bool:
+    """Pure check — unlike _has_recent_duplicate it does NOT set the cache key.
+
+    Used by the confirm-then-post scan flow so a cancelled or failed
+    confirmation never blocks the operator from re-scanning the same label.
+    """
+    if not raw_code:
+        return False
+    return bool(frappe.cache().get_value(_scan_cache_key(work_order, raw_code)))
+
+def _mark_scan_consumed(work_order: str, raw_code: str, ttl_sec: Optional[int] = None) -> None:
+    """Record that a raw scan was consumed, so a quick re-scan is rejected."""
+    if not raw_code:
+        return
+    frappe.cache().set_value(
+        _scan_cache_key(work_order, raw_code), "1",
+        expires_in_sec=ttl_sec or _scan_dup_ttl(),
+    )
+
 def _require_roles(roles: list[str]):
     if frappe.session.user == "Guest":
         frappe.throw(_("Login required"))
@@ -3601,12 +3620,26 @@ def get_materials_snapshot(work_order: str):
 
 @frappe.whitelist()
 def parse_scan(code: str):
+    """
+    Parse a scanned barcode into item/batch/qty without moving any stock.
+
+    The returned `barcode_qty` is the quantity embedded in the barcode (0 when
+    the barcode carries none). It is informational only — for an aggregated
+    Storekeeper label it may cover several Work Orders, so callers must NOT
+    consume it directly; the operator confirms the quantity to consume.
+    """
     out = _parse_gs1_or_basic(code or "")
     item_code = out.get("item_code")
     if not item_code:
         return {"ok": False, "msg": _("Cannot parse item from code")}
     uom = frappe.db.get_value("Item", item_code, "stock_uom") or "Nos"
-    return {"ok": True, "item_code": item_code, "batch_no": out.get("batch_no"), "uom": uom}
+    return {
+        "ok": True,
+        "item_code": item_code,
+        "batch_no": out.get("batch_no"),
+        "barcode_qty": flt(out.get("qty") or 0),
+        "uom": uom,
+    }
 
 @frappe.whitelist()
 def get_staging_batches(work_order: str, item_code: str):
@@ -3732,28 +3765,29 @@ def get_manual_load_item_context(work_order: str, item_code: str):
     }
 
 
-@frappe.whitelist()
-def manual_load_materials(work_order: str, items: str):
+def _post_material_consumption_for_wo(work_order: str, items: list) -> dict:
     """
-    Manually consume materials from WIP warehouse into a Work Order without barcode scanning.
+    Validate and post a single "Material Consumption for Manufacture" Stock
+    Entry for `work_order`, with one row per item in `items`.
 
-    items: JSON list of {"item_code": str, "batch_no": str|null, "qty": float}
+    Each item dict: {"item_code": str, "batch_no": str|None, "qty": float}.
 
-    Creates a single "Material Consumption for Manufacture" Stock Entry with one row per item.
+    Shared by manual_load_materials() and consume_scanned_material() so the
+    validation lives in exactly one place. Callers handle their own role checks.
+
+    Per-item validation: Work Order not ended, item exists, item belongs to the
+    WO BOM unless it is in a packaging group, and total consumption stays within
+    the material_overconsumption_threshold. The Stock Entry consumes from the
+    Work Order line WIP warehouse and is linked to the Work Order.
+
     Returns {"ok": True, "msg": str, "stock_entry": str}.
     """
-    _require_roles(ROLES_OPERATOR)
-
     if not work_order:
         frappe.throw(_("Missing work_order"))
 
     _assert_not_ended(work_order)
 
-    try:
-        item_list = json.loads(items) if isinstance(items, str) else items
-    except Exception:
-        item_list = []
-    if not item_list:
+    if not items:
         frappe.throw(_("No items provided"))
 
     wo = frappe.get_doc("Work Order", work_order)
@@ -3772,7 +3806,7 @@ def manual_load_materials(work_order: str, items: str):
     se.bom_no = wo.bom_no
     se.fg_completed_qty = flt(wo.qty) - flt(wo.produced_qty)
 
-    for it in item_list:
+    for it in items:
         item_code = (it.get("item_code") or "").strip()
         qty = float(it.get("qty") or 0)
         if not item_code or qty <= 0:
@@ -3848,6 +3882,74 @@ def manual_load_materials(work_order: str, items: str):
 
     count = len(se.items)
     return {"ok": True, "msg": _("Consumed {0} item(s)").format(count), "stock_entry": se.name}
+
+
+@frappe.whitelist()
+def manual_load_materials(work_order: str, items: str):
+    """
+    Manually consume materials from WIP warehouse into a Work Order without barcode scanning.
+
+    items: JSON list of {"item_code": str, "batch_no": str|null, "qty": float}
+
+    Creates a single "Material Consumption for Manufacture" Stock Entry with one row per item.
+    Returns {"ok": True, "msg": str, "stock_entry": str}.
+    """
+    _require_roles(ROLES_OPERATOR)
+
+    try:
+        item_list = json.loads(items) if isinstance(items, str) else items
+    except Exception:
+        item_list = []
+
+    return _post_material_consumption_for_wo(work_order, item_list or [])
+
+
+@frappe.whitelist()
+def consume_scanned_material(work_order: str, item_code: str, qty,
+                             batch_no: str = None, raw_code: str = None):
+    """
+    Post a single confirmed scanned-material consumption against a Work Order.
+
+    The Operator Hub "Load Materials" scan flow parses a barcode, shows the
+    operator a quantity-confirmation dialog, then calls this method with the
+    operator-confirmed quantity.
+
+    IMPORTANT: the barcode quantity is never consumed here. A Storekeeper label
+    may carry an aggregate quantity staged for several Work Orders, so only the
+    confirmed `qty` is posted against this Work Order.
+
+    Validation/posting is shared with Manual Load via
+    _post_material_consumption_for_wo().
+
+    Returns {"ok": True, "msg": str, "stock_entry": str}.
+    """
+    _require_roles(ROLES_OPERATOR)
+
+    item_code = (item_code or "").strip()
+    if not work_order or not item_code:
+        frappe.throw(_("Missing work_order or item_code"))
+
+    qty = flt(qty)
+    if qty <= 0:
+        frappe.throw(_("Quantity to consume must be greater than zero"))
+
+    _assert_not_ended(work_order)
+
+    # Duplicate guard: reject only a label already consumed for this WO. The
+    # cache key is set *after* a successful post (below), so a cancelled or
+    # failed confirmation never blocks a re-scan of the same label.
+    if _scan_already_consumed(work_order, raw_code):
+        frappe.throw(_("This label was already consumed for this Work Order"))
+
+    result = _post_material_consumption_for_wo(
+        work_order,
+        [{"item_code": item_code, "batch_no": (batch_no or "").strip() or None, "qty": qty}],
+    )
+
+    _mark_scan_consumed(work_order, raw_code)
+
+    result["msg"] = _("Consumed {0} of {1}").format(qty, item_code)
+    return result
 
 
 @frappe.whitelist()

--- a/isnack/isnack/page/operator_hub/operator_hub.css
+++ b/isnack/isnack/page/operator_hub/operator_hub.css
@@ -533,6 +533,10 @@
   border-left-color: #ef4444;
   background: #fef2f2;
 }
+.op-teal .scan-cancelled{
+  border-left-color: #f59e0b;
+  background: #fffbeb;
+}
 .op-teal .scan-code{
   font-size: 0.85em;
   background: #ffffff;

--- a/isnack/isnack/page/operator_hub/operator_hub.js
+++ b/isnack/isnack/page/operator_hub/operator_hub.js
@@ -15,10 +15,6 @@ function init_operator_hub($root) {
   // Scan history configuration constants
   const SCAN_CODE_MAX_LENGTH = 60;
   const SCAN_HISTORY_MAX_ENTRIES = 20;
-  // Pattern to extract item code from backend messages like "Consumed X unit of ITEM123" or "item ABC-XYZ"
-  const SCAN_ITEM_PATTERN = /(?:of|item)\s+([A-Z0-9_-]+)/i;
-  // Pattern to extract quantity from backend messages like "Consumed 12.5 Kg" or "consumed 1 Nos"
-  const SCAN_QTY_PATTERN = /consumed\s+([\d.]+)\s+(\w+)/i;
   // Delay between opening multiple print dialogs to prevent browser blocking
   const PRINT_DIALOG_DELAY_MS = 500;
 
@@ -687,9 +683,18 @@ function init_operator_hub($root) {
   const okTone  = new Audio('/assets/frappe/sounds/submit.mp3');
   const errTone = new Audio('/assets/frappe/sounds/cancel.mp3');
   const $scanStatus = $('#scan-status');
+  // True while a scanned-material quantity-confirmation dialog is open. The
+  // scan handler rejects new scans until the operator confirms or cancels.
+  let awaitingQtyConfirm = false;
 
   async function handleScanValue(raw) {
     if (!raw) return;
+
+    // Guard: a quantity-confirmation dialog is already open for a prior scan.
+    if (awaitingQtyConfirm) {
+      flashStatus('Finish the current quantity confirmation first', 'warning');
+      return;
+    }
     if (/^EMP:/i.test(raw)) {
       flashStatus('Use Set Operator to choose the operator', 'warning');
       return;
@@ -702,87 +707,220 @@ function init_operator_hub($root) {
       return;
     }
 
+    // Pause scanner focus mode so the quantity dialog keeps focus, and block
+    // further scans until the operator finishes confirming this one.
+    awaitingQtyConfirm = true;
+    setScanMode(false);
     setStatus('Processing scan…');
-    
-    // Add timestamp for this scan
-    const scanTime = new Date().toLocaleTimeString();
-    
-    rpc('isnack.api.mes_ops.scan_material', { work_order: state.current_wo, code: raw })
-      .then(async r => {
-        const { ok, msg } = r.message || {};
-        const safeMsg = msg || 'Scan processed';
-        frappe.show_alert({ message: safeMsg, indicator: ok ? 'green' : 'red' });
-        
-        // Update scan history in dialog if it exists
-        const $scanHistoryList = $('#scan-history-list');
-        if ($scanHistoryList.length > 0) {
-          // Remove "no scans yet" message if it exists
-          if ($scanHistoryList.find('.scan-history-empty').length > 0) {
-            $scanHistoryList.empty();
+
+    try {
+      await showScannedMaterialQtyDialog(raw);
+    } finally {
+      awaitingQtyConfirm = false;
+      setScanMode(true);
+      focus_scan();
+    }
+  }
+
+  // Render one scan-history row inside the open Load / Scan Materials dialog.
+  // entry.status is 'Success' | 'Failed' | 'Cancelled'.
+  function appendScanHistory(entry) {
+    const $list = $('#scan-history-list');
+    if (!$list.length) return;
+    $list.find('.scan-history-empty').remove();
+
+    const ok = entry.status === 'Success';
+    const cancelled = entry.status === 'Cancelled';
+    const statusClass = ok ? 'scan-success' : (cancelled ? 'scan-cancelled' : 'scan-failed');
+    const statusIcon  = ok ? '✓' : (cancelled ? '⊘' : '✗');
+    const badgeClass  = ok ? 'bg-success' : (cancelled ? 'bg-secondary' : 'bg-danger');
+
+    const rawCode = entry.raw || '';
+    const safeRaw = frappe.utils.escape_html(rawCode.substring(0, SCAN_CODE_MAX_LENGTH))
+      + (rawCode.length > SCAN_CODE_MAX_LENGTH ? '...' : '');
+    const uomSuffix = entry.uom ? ' ' + frappe.utils.escape_html(entry.uom) : '';
+
+    const rows = [];
+    if (entry.itemCode) {
+      rows.push('<div class="small mb-1"><strong>Item:</strong> ' + frappe.utils.escape_html(entry.itemCode) + '</div>');
+    }
+    if (entry.batchNo) {
+      rows.push('<div class="small mb-1"><strong>Batch:</strong> ' + frappe.utils.escape_html(entry.batchNo) + '</div>');
+    }
+    if (entry.barcodeQty != null) {
+      rows.push('<div class="small mb-1"><strong>Barcode Qty:</strong> ' + frappe.utils.escape_html(String(entry.barcodeQty)) + uomSuffix + '</div>');
+    }
+    if (entry.consumedQty != null) {
+      rows.push('<div class="small mb-1"><strong>Consumed Qty:</strong> ' + frappe.utils.escape_html(String(entry.consumedQty)) + uomSuffix + '</div>');
+    }
+
+    const $entry = $(`
+      <div class="scan-entry ${statusClass} mb-2 p-2">
+        <div class="d-flex justify-content-between align-items-start mb-1">
+          <span class="badge ${badgeClass} me-2">${statusIcon} ${frappe.utils.escape_html(entry.status)}</span>
+          <span class="text-muted small">${frappe.utils.escape_html(entry.scanTime || '')}</span>
+        </div>
+        <div class="small mb-1"><strong>Raw Code:</strong> <code class="scan-code">${safeRaw}</code></div>
+        ${rows.join('')}
+        ${entry.message ? '<div class="small text-muted">' + frappe.utils.escape_html(entry.message) + '</div>' : ''}
+      </div>
+    `);
+
+    $list.prepend($entry);
+    if ($list.children().length > SCAN_HISTORY_MAX_ENTRIES) {
+      $list.children().last().remove();
+    }
+    $list.scrollTop(0);
+  }
+
+  // Parse a scanned barcode, fetch WO-specific material context, then open a
+  // quantity-confirmation dialog. Returns a Promise that resolves ONLY once
+  // that dialog is fully closed, so handleScanValue can safely resume the
+  // scanner afterwards.
+  function showScannedMaterialQtyDialog(raw) {
+    return new Promise((resolve) => {
+      const scanTime = new Date().toLocaleTimeString();
+
+      (async () => {
+        try {
+          const pr = await rpc('isnack.api.mes_ops.parse_scan', { code: raw });
+          const parsed = pr && pr.message;
+          if (!parsed || !parsed.ok) {
+            const msg = (parsed && parsed.msg) || 'Could not parse barcode';
+            appendScanHistory({ raw, status: 'Failed', message: msg, scanTime });
+            $scanStatus.length && $scanStatus.text('Error').removeClass().addClass('badge bg-danger');
+            flashStatus(msg, 'error');
+            try { errTone.play().catch(()=>{}); } catch(_) {}
+            resolve();
+            return;
           }
-          
-          // Parse the barcode to extract item info from backend response message
-          // Using configurable patterns to match various message formats
-          let itemInfo = 'Unknown';
-          let qtyInfo = '';
-          
-          // Try to extract item code from the message
-          const itemMatch = safeMsg.match(SCAN_ITEM_PATTERN);
-          if (itemMatch) {
-            itemInfo = itemMatch[1];
-          }
-          
-          // Try to extract quantity from message
-          const qtyMatch = safeMsg.match(SCAN_QTY_PATTERN);
-          if (qtyMatch) {
-            qtyInfo = `${qtyMatch[1]} ${qtyMatch[2]}`;
-          }
-          
-          // Create scan entry with proper styling
-          const statusClass = ok ? 'scan-success' : 'scan-failed';
-          const statusIcon = ok ? '✓' : '✗';
-          const statusText = ok ? 'Success' : 'Failed';
-          const badgeClass = ok ? 'bg-success' : 'bg-danger';
-          
-          const scanEntry = $(`
-            <div class="scan-entry ${statusClass} mb-2 p-2">
-              <div class="d-flex justify-content-between align-items-start mb-1">
-                <span class="badge ${badgeClass} me-2">${statusIcon} ${statusText}</span>
-                <span class="text-muted small">${scanTime}</span>
-              </div>
-              <div class="small mb-1">
-                <strong>Raw Code:</strong> <code class="scan-code">${frappe.utils.escape_html(raw.substring(0, SCAN_CODE_MAX_LENGTH))}${raw.length > SCAN_CODE_MAX_LENGTH ? '...' : ''}</code>
-              </div>
-              ${itemInfo !== 'Unknown' ? `<div class="small mb-1"><strong>Item:</strong> ${frappe.utils.escape_html(itemInfo)}</div>` : ''}
-              ${qtyInfo ? `<div class="small mb-1"><strong>Qty:</strong> ${frappe.utils.escape_html(qtyInfo)}</div>` : ''}
-              <div class="small text-muted">${frappe.utils.escape_html(safeMsg)}</div>
-            </div>
-          `);
-          
-          // Prepend to show newest first
-          $scanHistoryList.prepend(scanEntry);
-          
-          // Limit to configured max entries
-          if ($scanHistoryList.children().length > SCAN_HISTORY_MAX_ENTRIES) {
-            $scanHistoryList.children().last().remove();
-          }
-          
-          // Auto-scroll to show the newest entry
-          $scanHistoryList.scrollTop(0);
+
+          const ctxr = await rpc('isnack.api.mes_ops.get_manual_load_item_context', {
+            work_order: state.current_wo,
+            item_code: parsed.item_code
+          });
+          const ctx = (ctxr && ctxr.message) || {};
+
+          const availr = await rpc('isnack.api.mes_ops.get_batch_available_qty', {
+            work_order: state.current_wo,
+            item_code: parsed.item_code,
+            batch_no: parsed.batch_no || ''
+          });
+          const avail = (availr && availr.message) || {};
+
+          const itemCode     = parsed.item_code;
+          const batchNo      = parsed.batch_no || '';
+          const barcodeQty   = parseFloat(parsed.barcode_qty) || 0;
+          const uom          = parsed.uom || avail.uom || ctx.uom || '';
+          const requiredQty  = parseFloat(ctx.required_qty) || 0;
+          const consumedQty  = parseFloat(ctx.consumed_qty) || 0;
+          const remainingQty = parseFloat(ctx.remaining_qty) || 0;
+          const availableQty = parseFloat(avail.qty) || 0;
+          // Default to what this WO still needs, capped by WIP availability —
+          // never the (possibly aggregated) barcode quantity.
+          const defaultQty = Math.max(Math.min(remainingQty, availableQty), 0);
+
+          let consumed = false;
+          let settled = false;
+
+          const d = opDialog({
+            title: 'Confirm Quantity to Consume',
+            fields: [
+              { fieldtype: 'Section Break' },
+              { label: 'Item Code', fieldname: 'item_code_ro', fieldtype: 'Data', read_only: 1, default: itemCode },
+              { fieldtype: 'Column Break' },
+              { label: 'Batch No', fieldname: 'batch_no_ro', fieldtype: 'Data', read_only: 1, default: batchNo || '—' },
+              { fieldtype: 'Section Break', label: 'Quantities (' + (uom || 'stock UOM') + ')' },
+              { label: 'Barcode Qty', fieldname: 'barcode_qty_ro', fieldtype: 'Float', read_only: 1, default: barcodeQty },
+              { label: 'Required Qty', fieldname: 'required_qty_ro', fieldtype: 'Float', read_only: 1, default: requiredQty },
+              { label: 'Already Consumed Qty', fieldname: 'consumed_qty_ro', fieldtype: 'Float', read_only: 1, default: consumedQty },
+              { fieldtype: 'Column Break' },
+              { label: 'Remaining Qty', fieldname: 'remaining_qty_ro', fieldtype: 'Float', read_only: 1, default: remainingQty },
+              { label: 'Available Qty in WIP', fieldname: 'available_qty_ro', fieldtype: 'Float', read_only: 1, default: availableQty },
+              { fieldtype: 'Section Break' },
+              { label: 'Qty to Consume', fieldname: 'qty', fieldtype: 'Float', reqd: 1, default: defaultQty },
+            ],
+            primary_action_label: 'Consume',
+            primary_action: async () => {
+              const qty = parseFloat(d.get_value('qty')) || 0;
+              if (qty <= 0) { frappe.msgprint('Enter a quantity greater than zero'); return; }
+
+              d.disable_primary_action();
+              setStatus('Posting consumption…');
+              try {
+                const r = await rpc('isnack.api.mes_ops.consume_scanned_material', {
+                  work_order: state.current_wo,
+                  item_code: itemCode,
+                  batch_no: batchNo,
+                  qty: qty,
+                  raw_code: raw
+                });
+                const msg = (r && r.message && r.message.msg) || 'Material consumed';
+                consumed = true;
+                appendScanHistory({
+                  raw, status: 'Success', itemCode, batchNo, uom,
+                  barcodeQty, consumedQty: qty, message: msg, scanTime
+                });
+                alerts.length && alerts.addClass('d-none').text('');
+                $scanStatus.length && $scanStatus.text('Material').removeClass().addClass('badge bg-success');
+                frappe.show_alert({ message: msg, indicator: 'green' });
+                flashStatus(msg, 'success');
+                try { okTone.play().catch(()=>{}); } catch(_) {}
+                if (state.current_wo) await load_materials_snapshot(state.current_wo);
+                d.hide();
+              } catch (e) {
+                const msg = (e && e.message) || 'Consumption failed';
+                appendScanHistory({
+                  raw, status: 'Failed', itemCode, batchNo, uom,
+                  barcodeQty, message: msg, scanTime
+                });
+                alerts.length && alerts.removeClass('d-none').text(msg);
+                $scanStatus.length && $scanStatus.text('Error').removeClass().addClass('badge bg-danger');
+                flashStatus(msg, 'error');
+                try { errTone.play().catch(()=>{}); } catch(_) {}
+                // Keep the dialog open so the operator can adjust and retry.
+                d.enable_primary_action();
+              }
+            }
+          });
+
+          d.set_secondary_action_label('Cancel');
+          d.set_secondary_action(() => d.hide());
+
+          // Resolve the outer Promise once — and only once — the dialog is
+          // fully closed (Consume success, Cancel, or corner close button).
+          const onClose = () => {
+            if (settled) return;
+            settled = true;
+            if (!consumed) {
+              appendScanHistory({
+                raw, status: 'Cancelled', itemCode, batchNo, uom,
+                barcodeQty, message: 'Confirmation cancelled — nothing consumed', scanTime
+              });
+              flashStatus('Scan cancelled — nothing consumed', 'warning');
+            }
+            resolve();
+          };
+          d.onhide = onClose;
+          d.$wrapper.on('hidden.bs.modal', onClose);
+
+          d.show();
+          // Keep the editable Qty field focused. The hidden scanner input is
+          // already paused (setScanMode(false)) so it cannot steal focus.
+          setTimeout(() => {
+            try {
+              const f = d.fields_dict.qty;
+              if (f && f.$input && f.$input.length) { f.$input.focus(); f.$input.select(); }
+            } catch (_) {}
+          }, 200);
+        } catch (e) {
+          const msg = (e && e.message) || 'Scan failed';
+          appendScanHistory({ raw, status: 'Failed', message: msg, scanTime });
+          try { errTone.play().catch(()=>{}); } catch(_) {}
+          resolve();
         }
-        
-        if (ok) {
-          alerts.length && alerts.addClass('d-none').text('');
-          $scanStatus.length && $scanStatus.text('Material').removeClass().addClass('badge bg-success');
-          flashStatus(safeMsg || 'Loaded material', 'success');
-          if (state.current_wo) await load_materials_snapshot(state.current_wo);
-          try { okTone.play().catch(()=>{}); } catch(_) {}
-        } else {
-          alerts.length && alerts.removeClass('d-none').text(safeMsg || 'Scan failed');
-          $scanStatus.length && $scanStatus.text('Error').removeClass().addClass('badge bg-danger');
-          flashStatus(safeMsg || 'Scan failed', 'error'); try { errTone.play().catch(()=>{}); } catch(_) {}
-        }
-      });
+      })();
+    });
   }
 
   scan.on('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); const raw = scan.val().trim(); scan.val(''); handleScanValue(raw); } });


### PR DESCRIPTION
## Summary
Refactored the material scanning workflow in Operator Hub to separate barcode parsing from consumption posting. The operator now confirms the quantity to consume in a dialog before any stock movement occurs, improving control and error recovery.

## Key Changes

**Frontend (operator_hub.js):**
- Removed hardcoded regex patterns for extracting item/quantity from backend messages
- Introduced `awaitingQtyConfirm` flag to prevent concurrent scan processing while a confirmation dialog is open
- Split `handleScanValue()` into two phases:
  1. Parse the barcode via new `parse_scan()` RPC
  2. Show quantity-confirmation dialog via new `showScannedMaterialQtyDialog()` function
- New `appendScanHistory()` function renders scan entries with structured data (itemCode, batchNo, barcodeQty, consumedQty) instead of parsing message text
- Dialog displays:
  - Barcode quantity (informational only)
  - Work Order requirements (required, consumed, remaining)
  - Available quantity in WIP warehouse
  - Operator-editable "Qty to Consume" field (defaults to remaining qty capped by availability)
- Added "Cancelled" status to scan history with amber styling
- Scanner input is paused (`setScanMode(false)`) while dialog is open to prevent focus theft

**Backend (mes_ops.py):**
- New `parse_scan()` RPC: parses barcode into item/batch/qty without moving stock; returns `barcode_qty` as informational field
- New `consume_scanned_material()` RPC: posts a single confirmed consumption with operator-provided quantity (not barcode quantity)
- Refactored `manual_load_materials()` to call shared `_post_material_consumption_for_wo()` helper
- New helper `_post_material_consumption_for_wo()`: centralizes validation and Stock Entry creation for both manual and scanned flows
- New cache helpers:
  - `_scan_already_consumed()`: pure check (does not set cache)
  - `_mark_scan_consumed()`: records successful consumption to prevent quick re-scans
- Duplicate guard: only blocks re-scans of labels already successfully consumed; cancelled/failed confirmations do not block re-scanning

## Notable Implementation Details

- **Barcode quantity is never consumed directly**: Storekeeper labels may aggregate quantities for multiple Work Orders, so only the operator-confirmed quantity is posted
- **Error recovery**: If confirmation fails or is cancelled, the label can be re-scanned immediately without cache blocking
- **Dialog focus management**: Quantity field is auto-focused and selected after dialog opens; scanner input is paused to prevent interference
- **Structured scan history**: Entries now store parsed data (itemCode, batchNo, barcodeQty, consumedQty) rather than parsing message text, improving reliability and consistency

https://claude.ai/code/session_01Jv2DRmcmaSU3D7nTu8k6UA