### PR TITLE
feat: pallet label reprint from the Production Plan form

### DIFF
--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -2250,6 +2250,123 @@ def get_pallet_label_data(lines: str = None):
         "allowed_pallet_uoms": allowed_pallet_uoms
     }
 
+
+def _pallet_label_print_summary(work_orders: list) -> dict:
+    """
+    Summarise prior *pallet*-label prints for a set of Work Orders so the
+    reprint screen can show what was already printed.
+
+    Pallet-label prints are identified by their Label Record payload carrying a
+    "pallet_type" (set by print_pallet_label); plain carton-label records are
+    ignored.
+
+    Returns {"printed_wo_count": int, "label_count": int, "last_printed_on": datetime|None}.
+    """
+    summary = {"printed_wo_count": 0, "label_count": 0, "last_printed_on": None}
+    if not work_orders:
+        return summary
+
+    src_rows = frappe.get_all(
+        "Label Record Source",
+        filters={"source_doctype": "Work Order", "source_docname": ["in", work_orders]},
+        fields=["source_docname", "parent"],
+    )
+    if not src_rows:
+        return summary
+
+    parent_names = list({r["parent"] for r in src_rows})
+    records = frappe.get_all(
+        "Label Record",
+        filters={"name": ["in", parent_names]},
+        fields=["name", "payload", "creation"],
+    )
+
+    pallet_records = {}
+    for rec in records:
+        try:
+            payload = json.loads(rec.get("payload") or "{}")
+        except Exception:
+            payload = {}
+        if payload.get("pallet_type"):
+            pallet_records[rec["name"]] = rec["creation"]
+
+    if not pallet_records:
+        return summary
+
+    printed_wos = {r["source_docname"] for r in src_rows if r["parent"] in pallet_records}
+    summary["printed_wo_count"] = len(printed_wos)
+    summary["label_count"] = len(pallet_records)
+    summary["last_printed_on"] = max(pallet_records.values())
+    return summary
+
+
+@frappe.whitelist()
+def get_pallet_label_data_for_production_plan(production_plan: str):
+    """
+    Pallet label data for the closed (status Completed) Work Orders of a
+    Production Plan, grouped per production item. Data source for the
+    pallet-label reprint dialog on the Production Plan form.
+
+    Mirrors get_pallet_label_data but is scoped to a Production Plan instead of
+    a factory line + today, and adds a printed-status summary per item so the
+    production manager can see which pallet labels were already printed before
+    reprinting. Carton Qty is the produced quantity, summed across the WOs.
+    """
+    _require_roles(ROLES_OPERATOR)
+
+    if not production_plan:
+        return {"items": [], "allowed_pallet_uoms": []}
+
+    work_orders = frappe.get_all(
+        "Work Order",
+        filters={"production_plan": production_plan, "status": "Completed"},
+        fields=["name", "production_item", "produced_qty"],
+        order_by="creation asc",
+    )
+
+    # Group by production_item
+    grouped = {}
+    for wo in work_orders:
+        item_code = wo["production_item"]
+        if item_code not in grouped:
+            grouped[item_code] = {"item_code": item_code, "work_orders": [], "qty": 0}
+        grouped[item_code]["work_orders"].append(wo["name"])
+        grouped[item_code]["qty"] += flt(wo.get("produced_qty", 0))
+
+    # Enrich with item details and printed status
+    items = []
+    for item_code, data in grouped.items():
+        item_details = frappe.db.get_value(
+            "Item", item_code, ["item_name", "description", "stock_uom"], as_dict=True
+        )
+        if not item_details:
+            continue
+        printed = _pallet_label_print_summary(data["work_orders"])
+        items.append({
+            "item_code": item_code,
+            "item_name": item_details.get("item_name", ""),
+            "description": item_details.get("description", ""),
+            "default_uom": item_details.get("stock_uom", ""),
+            "carton_qty": data["qty"],
+            "work_orders": data["work_orders"],
+            "total_wo_count": len(data["work_orders"]),
+            "printed_wo_count": printed["printed_wo_count"],
+            "label_count": printed["label_count"],
+            "last_printed_on": printed["last_printed_on"],
+        })
+
+    # Allowed pallet UOMs from Factory Settings
+    allowed_pallet_uoms = []
+    try:
+        fs = frappe.get_cached_doc("Factory Settings")
+        if hasattr(fs, "pallet_uom_options") and fs.pallet_uom_options:
+            allowed_pallet_uoms = [row.uom for row in fs.pallet_uom_options if row.uom]
+    except Exception:
+        pass
+
+    return {"items": items, "allowed_pallet_uoms": allowed_pallet_uoms}
+
+
 @frappe.whitelist()
 def get_pallet_conversion_factor(item_code: str, from_uom: str, to_uom: str):
     """

--- a/isnack/public/js/production_plan.js
+++ b/isnack/public/js/production_plan.js
@@ -9,6 +9,12 @@ frappe.ui.form.on("Production Plan", {
         __("View")
       );
     }
+
+    if (!frm.doc.__islocal && frm.doc.docstatus === 1) {
+      frm.add_custom_button(__("Print Pallet Labels"), () =>
+        isnack_show_pallet_label_dialog(frm)
+      );
+    }
   },
 
   make_work_order(frm) {
@@ -73,3 +79,195 @@ frappe.ui.form.on("Production Plan", {
     });
   },
 });
+
+// Pallet-label reprint dialog for a Production Plan's closed Work Orders.
+// Self-contained (not shared with the Operator Hub dialog) and read-only —
+// it only reprints labels, it does not move stock or change Work Orders.
+async function isnack_show_pallet_label_dialog(frm) {
+  const production_plan = frm.doc.name;
+
+  const default_print_format = await frappe.db.get_single_value(
+    "Factory Settings",
+    "default_fg_label_print_format"
+  );
+  if (!default_print_format) {
+    frappe.msgprint({
+      title: __("Configuration Error"),
+      message: __(
+        'No default label print format is configured in Factory Settings. Please set "Default FG Label Print Format" before printing labels.'
+      ),
+      indicator: "red",
+    });
+    return;
+  }
+
+  let pallet_data;
+  try {
+    const r = await frappe.call({
+      method: "isnack.api.mes_ops.get_pallet_label_data_for_production_plan",
+      args: { production_plan },
+    });
+    pallet_data = (r && r.message) || {};
+  } catch (e) {
+    frappe.msgprint({
+      title: __("Error"),
+      message: __("Failed to load pallet label data."),
+      indicator: "red",
+    });
+    return;
+  }
+
+  const items = pallet_data.items || [];
+  const allowed_pallet_uoms = pallet_data.allowed_pallet_uoms || [];
+
+  if (!items.length) {
+    frappe.msgprint(__("No closed Work Orders found for this Production Plan."));
+    return;
+  }
+
+  // Recalculate pallet_qty for a grid row from its carton qty + pallet type.
+  async function calculate_pallet_qty(row) {
+    if (!row || !row.doc) return;
+    const pallet_type = row.doc.pallet_type;
+    const carton_qty = row.doc.carton_qty || 0;
+    if (!pallet_type || !carton_qty) {
+      row.doc.pallet_qty = null;
+      row.refresh();
+      return;
+    }
+    try {
+      const r = await frappe.call({
+        method: "isnack.api.mes_ops.get_pallet_conversion_factor",
+        args: {
+          item_code: row.doc.item_code,
+          from_uom: row.doc.default_uom,
+          to_uom: pallet_type,
+        },
+      });
+      const result = (r && r.message) || {};
+      if (result.found && result.conversion_factor) {
+        row.doc.pallet_qty = carton_qty / result.conversion_factor;
+      } else {
+        row.doc.pallet_qty = null;
+      }
+      row.refresh();
+    } catch (err) {
+      frappe.show_alert({
+        message: __("Failed to get conversion factor"),
+        indicator: "orange",
+      });
+    }
+  }
+
+  const d = new frappe.ui.Dialog({
+    title: __("Print Pallet Label (FG only)"),
+    size: "extra-large",
+    fields: [
+      {
+        fieldname: "pallet_items",
+        fieldtype: "Table",
+        label: __("Pallet Label Items"),
+        cannot_add_rows: true,
+        cannot_delete_rows: true,
+        in_place_edit: true,
+        data: [],
+        fields: [
+          { fieldname: "item_code", fieldtype: "Data", label: __("Item Code"), in_list_view: 1, read_only: 1, columns: 2 },
+          { fieldname: "description", fieldtype: "Data", label: __("Description"), in_list_view: 1, read_only: 1, columns: 2 },
+          { fieldname: "carton_qty", fieldtype: "Float", label: __("Carton Qty"), in_list_view: 1, read_only: 0, columns: 1,
+            onchange: function () { calculate_pallet_qty(this.grid_row); } },
+          { fieldname: "pallet_type", fieldtype: "Link", label: __("Pallet Type"), in_list_view: 1, options: "UOM", columns: 2,
+            get_query: () => ({ filters: { name: ["in", allowed_pallet_uoms] } }),
+            onchange: function () { calculate_pallet_qty(this.grid_row); } },
+          { fieldname: "pallet_qty", fieldtype: "Float", label: __("Pallet Qty"), in_list_view: 1, read_only: 0, columns: 1 },
+          { fieldname: "printed_status", fieldtype: "Data", label: __("Printed"), in_list_view: 1, read_only: 1, columns: 2 },
+          { fieldname: "default_uom", fieldtype: "Data", label: __("Default UOM"), in_list_view: 0 },
+          { fieldname: "work_orders", fieldtype: "Data", label: __("Work Orders"), hidden: 1, in_list_view: 0 },
+        ],
+      },
+    ],
+    primary_action_label: __("Print Labels"),
+    primary_action: async () => {
+      const grid_data = d.fields_dict.pallet_items.grid.get_data();
+      const rows_to_print = grid_data.filter(
+        (row) => row.pallet_type && row.pallet_qty > 0
+      );
+      if (!rows_to_print.length) {
+        frappe.show_alert({
+          message: __("Select a pallet type and quantity for at least one item"),
+          indicator: "orange",
+        });
+        return;
+      }
+
+      d.disable_primary_action();
+      let printed_count = 0;
+      for (const row of rows_to_print) {
+        try {
+          const r = await frappe.call({
+            method: "isnack.api.mes_ops.print_pallet_label",
+            args: {
+              item_code: row.item_code,
+              pallet_qty: row.pallet_qty,
+              pallet_type: row.pallet_type,
+              work_orders: JSON.stringify(row.work_orders || []),
+              template: default_print_format,
+            },
+          });
+          const urls = ((r && r.message) || {}).print_urls || [];
+          for (let i = 0; i < urls.length; i++) {
+            if (printed_count > 0) {
+              await new Promise((res) => setTimeout(res, 500));
+            }
+            window.open(urls[i], "_blank");
+            printed_count++;
+          }
+        } catch (err) {
+          frappe.show_alert({
+            message: __("Failed to print label for {0}", [row.item_code]),
+            indicator: "red",
+          });
+        }
+      }
+
+      if (printed_count > 0) {
+        frappe.show_alert({
+          message: __("{0} pallet label(s) opened for printing", [printed_count]),
+          indicator: "green",
+        });
+        d.hide();
+      } else {
+        d.enable_primary_action();
+      }
+    },
+  });
+
+  items.forEach((item) => {
+    const total = item.total_wo_count || 0;
+    const printed = item.printed_wo_count || 0;
+    const when = item.last_printed_on
+      ? " " + String(item.last_printed_on).slice(0, 10)
+      : "";
+    let printed_status;
+    if (printed === 0) {
+      printed_status = __("Not printed");
+    } else if (printed >= total) {
+      printed_status = __("Printed") + when;
+    } else {
+      printed_status = __("Partial ({0}/{1})", [printed, total]) + when;
+    }
+    d.fields_dict.pallet_items.df.data.push({
+      item_code: item.item_code,
+      description: item.item_name || item.description || "",
+      carton_qty: item.carton_qty,
+      pallet_type: "",
+      pallet_qty: 0,
+      printed_status: printed_status,
+      default_uom: item.default_uom,
+      work_orders: item.work_orders || [],
+    });
+  });
+  d.fields_dict.pallet_items.grid.refresh();
+
+  d.show();
+}


### PR DESCRIPTION
Adds a "Print Pallet Labels" button to submitted Production Plans so a production manager can reprint pallet labels for the plan's closed Work Orders — a durable, manager-facing entry point separate from the end-of-day Operator Hub flow.

New endpoint get_pallet_label_data_for_production_plan aggregates the Completed Work Orders of a Production Plan per production item (produced qty), and reports a printed-status summary per item (derived from Label Record / Label Record Source) so reprints are deliberate. The form dialog reuses the existing print_pallet_label and conversion-factor endpoints; no stock movement or Work Order changes are involved.

https://claude.ai/code/session_01Jv2DRmcmaSU3D7nTu8k6UA