### PR TITLE
Reorder toolbar buttons in storekeeper hub

### DIFF
--- a/isnack/isnack/page/storekeeper_hub/storekeeper_hub.html
+++ b/isnack/isnack/page/storekeeper_hub/storekeeper_hub.html
@@ -10,8 +10,8 @@
       </div>
 
       <div class="toolbar-actions">
-        <button class="btn btn-sm btn-info print-pallet-labels">Print Pallet Labels</button>
         <button class="btn btn-sm btn-success generate-picklist">Generate Picklist</button>
+        <button class="btn btn-sm btn-info print-pallet-labels">Print Pallet Labels</button>
 
         <div class="quick-stock-entries">
           <button class="btn btn-xs btn-default se-transfer">Mat. Transfer</button>


### PR DESCRIPTION
## Summary
Reordered the action buttons in the storekeeper hub toolbar to improve the logical workflow sequence.

## Changes
- Moved "Generate Picklist" button before "Print Pallet Labels" button
- This reflects a more intuitive user workflow where picklists are generated first, followed by printing pallet labels

## Details
The button order now follows the typical operational sequence in warehouse management, making the interface more intuitive for users who need to generate picklists before printing labels.

https://claude.ai/code/session_016e8TebRwTEu2qHZNzBUMXF