### PR TITLE
Leave Close Production batch number field empty

### DIFF
--- a/isnack/isnack/page/operator_hub/operator_hub.js
+++ b/isnack/isnack/page/operator_hub/operator_hub.js
@@ -2434,16 +2434,6 @@ function init_operator_hub($root) {
         }
       });
     }
-    
-    // Auto-generate and pre-fill batch number
-    rpc('isnack.api.mes_ops.generate_next_batch_code')
-      .then(result => {
-        const batchCode = result.message || result;
-        d.set_value('batch_no', batchCode);
-      })
-      .catch(err => {
-        console.warn('Failed to auto-generate batch code', err);
-      });
   });
 
   // Initial


### PR DESCRIPTION
The batch number field was auto-filled with a generated next code, which operators tended to accept blindly. Remove the pre-fill so the field opens empty and the operator must deliberately enter the batch number.

https://claude.ai/code/session_016e8TebRwTEu2qHZNzBUMXF