### PR TITLE
fix(operator-hub): align Close Production fields, compact WO chips

### DIFF
--- a/isnack/isnack/page/operator_hub/operator_hub.css
+++ b/isnack/isnack/page/operator_hub/operator_hub.css
@@ -1028,45 +1028,63 @@ body[data-route="operator-hub"].op-kiosk #kiosk-exit:hover{ opacity:1; }
 
 /* Header is provided by .op-dialog. */
 
-/* Ended WO list items — teal left-border accent + subtle teal-tinted background */
-.close-production-dialog [data-fieldname="ended_wo_list"] .border.rounded{
-  border-left: 4px solid #15b79e !important;
-  background: #f0fdf9;
-  transition: background .1s ease;
+/* Ended Work Orders — compact chip row */
+.close-production-dialog .cp-wo-chips{
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 6px;
 }
-.close-production-dialog [data-fieldname="ended_wo_list"] .border.rounded:hover{
-  background: #e0faf4;
+.close-production-dialog .cp-wo-chip{
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #f0fdf9;
+  border: 1px solid #99f6e4;
+  border-left: 4px solid #15b79e;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #134e4a;
+}
+.close-production-dialog .cp-wo-chip-qty{
+  color: #0f766e;
+  background: #ccfbf1;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-weight: 600;
 }
 
 /* Good Qty — green tint (positive output) */
-.close-production-dialog [data-fieldname="good_qty"] .form-control{
+.close-production-dialog [data-fieldname$="good_qty"] .form-control{
   background: #f0fdf4 !important;
   border-color: #86efac !important;
   color: #166534 !important;
 }
 
 /* Reject Qty — red/amber tint (waste) */
-.close-production-dialog [data-fieldname="reject_qty"] .form-control{
+.close-production-dialog [data-fieldname$="reject_qty"] .form-control{
   background: #fff5f5 !important;
   border-color: #fca5a5 !important;
   color: #9f1239 !important;
 }
 
 /* Batch No — amber highlight (key operator input) */
-.close-production-dialog [data-fieldname="batch_no"] .form-control{
+.close-production-dialog [data-fieldname$="batch_no"] .form-control{
   background: #fff3d6 !important;
   border-color: #fbbf24 !important;
 }
 
 /* Packaging qty fields — subtle blue tint */
-.close-production-dialog [data-fieldname^="pkg_"] .form-control{
+.close-production-dialog [data-fieldname*="_pkg_"] .form-control{
   background: #e8f1ff !important;
   border-color: #93c5fd !important;
 }
 
 /* Primary CTA + reduced-motion are provided by .op-dialog. */
 @media (prefers-reduced-motion: reduce){
-  .close-production-dialog [data-fieldname="ended_wo_list"] .border.rounded{
+  .close-production-dialog .cp-wo-chip{
     transition: none !important;
     animation: none !important;
   }

--- a/isnack/isnack/page/operator_hub/operator_hub.js
+++ b/isnack/isnack/page/operator_hub/operator_hub.js
@@ -2329,18 +2329,24 @@ function init_operator_hub($root) {
     const fields = [];
 
     productGroups.forEach((g, gIdx) => {
-      const sectionLabel = productGroups.length > 1
+      const titleSuffix = productGroups.length > 1
         ? `${g.item_name} (${g.production_item})`
-        : `Ended Work Orders — ${g.item_name}`;
-      fields.push({ fieldtype: 'Section Break', label: sectionLabel });
+        : g.item_name;
+
+      // Row 1: full-width WO list as compact chips.
+      fields.push({ fieldtype: 'Section Break', label: `Ended Work Orders — ${titleSuffix}` });
+      const chips = g.work_orders.map(wo =>
+        `<span class="cp-wo-chip"><strong>${frappe.utils.escape_html(wo.name)}</strong>`
+        + `<span class="cp-wo-chip-qty">Qty ${wo.qty}</span></span>`
+      ).join('');
       fields.push({
         fieldtype: 'HTML',
         fieldname: `g${gIdx}_wo_list`,
-        options: '<div class="mb-2">' + g.work_orders.map(wo =>
-          `<div class="border rounded p-2 mb-1"><strong>${wo.name}</strong> (Qty: ${wo.qty})</div>`
-        ).join('') + '</div>',
+        options: `<div class="cp-wo-chips">${chips}</div>`,
       });
 
+      // Row 2: production quantities — three aligned columns.
+      fields.push({ fieldtype: 'Section Break', label: 'Production Quantities' });
       fields.push({ label:'Total Good Qty',   fieldname:`g${gIdx}_good_qty`,   fieldtype:'Float', reqd:1, default: 0 });
       fields.push({ fieldtype: 'Column Break' });
       fields.push({ label:'Total Reject Qty', fieldname:`g${gIdx}_reject_qty`, fieldtype:'Float', default: 0 });
@@ -2353,22 +2359,30 @@ function init_operator_hub($root) {
         description: '3 letters + dash + 3 digits (e.g., CGB-151). Dash auto-inserted.',
       });
 
+      // Row 3: packaging — two columns to keep the dialog compact.
       if (g.packaging_items.length) {
-        fields.push({ fieldtype: 'Section Break', label: `${g.item_name} — Packaging Materials Used` });
+        fields.push({ fieldtype: 'Section Break', label: 'Packaging Materials Used' });
         fields.push({
           fieldtype: 'HTML',
           fieldname: `g${gIdx}_packaging_help`,
           options: `<div class="text-muted small mb-2">Enter total quantities of packaging materials used across this product's ended work orders.</div>`,
         });
         g.packaging_items.forEach((item, idx) => {
-          const batchLabel = item.batch_no ? ` [Batch: ${item.batch_no}]` : '';
-          const consumedLabel = item.consumed_qty != null ? ` (Consumed: ${item.consumed_qty})` : '';
+          const batchLabel = item.batch_no ? ` · Batch ${item.batch_no}` : '';
+          const uomLabel = item.stock_uom ? `UOM: ${item.stock_uom}` : '';
+          const consumedLabel = item.consumed_qty != null ? ` · Already consumed: ${item.consumed_qty}` : '';
+          if (idx > 0 && idx % 2 === 0) {
+            fields.push({ fieldtype: 'Section Break' });
+          }
+          if (idx % 2 === 1) {
+            fields.push({ fieldtype: 'Column Break' });
+          }
           fields.push({
             label: `${item.item_code} — ${item.item_name || ''}${batchLabel}`,
             fieldname: `g${gIdx}_pkg_${idx}`,
             fieldtype: 'Float',
             default: 0,
-            description: `${item.stock_uom ? 'UOM: ' + item.stock_uom : ''}${consumedLabel}`,
+            description: `${uomLabel}${consumedLabel}`,
           });
         });
       }


### PR DESCRIPTION
The Close Production dialog stacked Total Good Qty in column 1 below the WO list while Total Reject Qty and Batch No sat at the top of columns 2 and 3, leaving the three primary inputs visibly misaligned.

- Move the WO list into its own full-width row above the inputs and start a fresh section for Total Good Qty / Total Reject Qty / Batch No so all three inputs land on the same row.
- Render the WO list as a compact chip row instead of stacked bordered cards so the dialog isn't dominated by it.
- Lay packaging fields out in two columns to halve vertical scroll.
- Refresh the dialog CSS for the new per-group field names (g{N}_good_qty, g{N}_reject_qty, g{N}_batch_no, g{N}_pkg_{idx}) using suffix/contains selectors so the colour treatment still applies. Add styles for the new .cp-wo-chip element.