### PR TITLE
Add Factory Settings toggle for per-user label printer routing

### DIFF
--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -13,6 +13,7 @@ from isnack.isnack.page.storekeeper_hub.storekeeper_hub import (
     _stage_status as _storekeeper_stage_status,
     _process_batch_spaces,
 )
+from isnack.utils.printing import get_label_printer
 
 # ============================================================
 # Factory Settings helpers (Single doctype)
@@ -3287,7 +3288,7 @@ def print_label(carton_qty, template: Optional[str] = None, printer: Optional[st
     
     # Get silent printing settings
     enable_silent_printing = getattr(fs, "enable_silent_printing", False)
-    default_label_printer = getattr(fs, "default_label_printer", None)
+    default_label_printer = get_label_printer(fs)
     
     return {
         "success": True,
@@ -3406,7 +3407,7 @@ def print_pallet_label(item_code: str, pallet_qty: float, pallet_type: str,
     
     # Get silent printing settings
     enable_silent_printing = getattr(fs, "enable_silent_printing", False)
-    default_label_printer = getattr(fs, "default_label_printer", None)
+    default_label_printer = get_label_printer(fs)
 
     base_url = _generate_print_url("Work Order", first_work_order, template)
     pallet_type_q = frappe.utils.quote(pallet_type)
@@ -3570,7 +3571,7 @@ def print_label_record(label_record: str, printer: Optional[str] = None, quantit
     
     # Create print jobs for audit trail (only if printer is provided)
     fs = _fs()
-    target_printer = printer or getattr(fs, "default_label_printer", None)
+    target_printer = printer or get_label_printer(fs)
     
     jobs = []
     print_urls = []
@@ -3755,7 +3756,7 @@ def combine_label_records(label_records, reason_code: Optional[str] = None, prin
             )
 
     fs = _fs()
-    target_printer = printer or getattr(fs, "default_label_printer", None)
+    target_printer = printer or get_label_printer(fs)
 
     first_source = combined.sources[0] if combined.sources else None
     source_doctype = first_source.source_doctype if first_source else None

--- a/isnack/isnack/doctype/factory_settings/factory_settings.json
+++ b/isnack/isnack/doctype/factory_settings/factory_settings.json
@@ -34,6 +34,7 @@
   "enable_silent_printing",
   "pallet_uom_options",
   "per_user_printer_defaults_section",
+  "use_per_user_printer_defaults",
   "user_printer_defaults"
  ],
  "fields": [
@@ -205,6 +206,14 @@
    "label": "Per User Printer Defaults"
   },
   {
+   "default": "0",
+   "description": "When enabled, label and A4 printing routes through the matching row in the User Printer Defaults table for the logged-in user. When disabled (default), every user prints to the global Default Label Printer / Default A4 Printer above.",
+   "fieldname": "use_per_user_printer_defaults",
+   "fieldtype": "Check",
+   "label": "Use Per User Printer Defaults"
+  },
+  {
+   "depends_on": "eval:doc.use_per_user_printer_defaults",
    "fieldname": "user_printer_defaults",
    "fieldtype": "Table",
    "label": "User Printer Defaults",
@@ -235,7 +244,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-02-17 21:34:24.423904",
+ "modified": "2026-05-27 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Isnack",
  "name": "Factory Settings",

--- a/isnack/isnack/page/storekeeper_hub/storekeeper_hub.py
+++ b/isnack/isnack/page/storekeeper_hub/storekeeper_hub.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.utils import now_datetime, add_to_date, cstr, nowdate, flt, getdate, cint
 from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_receipt 
 from erpnext.stock.doctype.batch.batch import get_batch_qty
+from isnack.utils.printing import get_label_printer
 
 # --- Helpers -----------------------------------------------------------------
 
@@ -917,7 +918,7 @@ def print_labels(stock_entry: str):
         fs = frappe.get_single("Factory Settings")
         fmt = getattr(fs, "default_label_print_format", None) or "SATO Label Print"
         enable_silent_printing = getattr(fs, "enable_silent_printing", False)
-        default_label_printer = getattr(fs, "default_label_printer", None)
+        default_label_printer = get_label_printer(fs)
     except Exception:
         fmt = "SATO Label Print"
         enable_silent_printing = False
@@ -1091,7 +1092,7 @@ def print_combined_pallet_labels(items):
             or "SATO Label Print"
         )
         enable_silent_printing = getattr(fs, "enable_silent_printing", False)
-        default_label_printer = getattr(fs, "default_label_printer", None)
+        default_label_printer = get_label_printer(fs)
     except Exception:
         fmt = "SATO Label Print"
         enable_silent_printing = False

--- a/isnack/utils/printing.py
+++ b/isnack/utils/printing.py
@@ -1,49 +1,106 @@
 import frappe
 from frappe.utils import cstr
 
+
 def get_factory_settings():
     try:
         return frappe.get_single("Factory Settings")
     except Exception:
         return frappe._dict()
 
-def _get_user_printer_row(fs=None):
-    fs = fs or get_factory_settings()
+
+def _per_user_enabled(fs) -> bool:
+    """Resolve the use_per_user_printer_defaults flag defensively.
+
+    Only a real bool ``True`` or a real ``int``/``str`` equal to ``1`` enables
+    per-user mode. Anything else — including ``MagicMock`` attribute access in
+    unit tests (which would otherwise coerce to ``1`` via ``__int__``),
+    missing field, or unparseable values — is treated as off, so the legacy
+    single-printer behavior is preserved by default.
+    """
+    val = getattr(fs, "use_per_user_printer_defaults", 0)
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, int):
+        return val == 1
+    if isinstance(val, str):
+        try:
+            return int(val.strip() or 0) == 1
+        except ValueError:
+            return False
+    return False
+
+
+def _get_user_printer_row(fs):
     user = frappe.session.user
-    for row in getattr(fs, "user_printer_defaults", []) or []:
-        if row.user == user:
+    rows = getattr(fs, "user_printer_defaults", None) or []
+    if not isinstance(rows, (list, tuple)):
+        return None
+    for row in rows:
+        if getattr(row, "user", None) == user:
             return row
     return None
 
-def get_label_printer() -> str | None:
-    """Best label printer for current user."""
-    fs = get_factory_settings()
 
-    # 1) Per-user override in Factory Settings
+def _global_label_printer(fs):
+    val = getattr(fs, "default_label_printer", None)
+    return cstr(val) if val else None
+
+
+def _global_a4_printer(fs):
+    val = getattr(fs, "default_a4_printer", None)
+    return cstr(val) if val else None
+
+
+def get_label_printer(fs=None) -> str | None:
+    """Best label printer for current user.
+
+    When ``use_per_user_printer_defaults`` is enabled on Factory Settings the
+    per-user row wins, then the global ``default_label_printer``, then the
+    system default in ``Print Settings``. When the flag is off (default) only
+    the global ``default_label_printer`` is consulted — matching the
+    historical ``getattr(fs, "default_label_printer", None)`` lookup the rest
+    of the codebase relied on.
+    """
+    fs = fs if fs is not None else get_factory_settings()
+
+    if not _per_user_enabled(fs):
+        return _global_label_printer(fs)
+
     row = _get_user_printer_row(fs)
-    if row and row.label_printer:
-        return row.label_printer
+    if row and getattr(row, "label_printer", None):
+        return cstr(row.label_printer)
 
-    # 2) Global default label printer (Factory Settings)
-    if getattr(fs, "default_label_printer", None):
-        return cstr(fs.default_label_printer)
+    glob = _global_label_printer(fs)
+    if glob:
+        return glob
 
-    # 3) System default printer
-    return frappe.db.get_single_value("Print Settings", "default_printer")
+    try:
+        return frappe.db.get_single_value("Print Settings", "default_printer")
+    except Exception:
+        return None
 
 
-def get_a4_printer() -> str | None:
-    """Best A4 / normal document printer for current user."""
-    fs = get_factory_settings()
+def get_a4_printer(fs=None) -> str | None:
+    """Best A4 / normal document printer for current user.
 
-    # 1) Per-user override in Factory Settings
+    Mirrors :func:`get_label_printer`: when per-user mode is off, the global
+    ``default_a4_printer`` is returned as-is (or ``None``).
+    """
+    fs = fs if fs is not None else get_factory_settings()
+
+    if not _per_user_enabled(fs):
+        return _global_a4_printer(fs)
+
     row = _get_user_printer_row(fs)
-    if row and row.a4_printer:
-        return row.a4_printer
+    if row and getattr(row, "a4_printer", None):
+        return cstr(row.a4_printer)
 
-    # 2) (optional) You can add a global default_a4_printer field on Factory Settings later
-    if getattr(fs, "default_a4_printer", None):
-        return cstr(fs.default_a4_printer)
+    glob = _global_a4_printer(fs)
+    if glob:
+        return glob
 
-    # 3) System default printer
-    return frappe.db.get_single_value("Print Settings", "default_printer")
+    try:
+        return frappe.db.get_single_value("Print Settings", "default_printer")
+    except Exception:
+        return None


### PR DESCRIPTION
Introduces a use_per_user_printer_defaults checkbox on Factory Settings.
When off (default) every print path resolves to the global Default Label
Printer exactly as before. When on, get_label_printer/get_a4_printer
consult the User Printer Defaults child table for the logged-in user and
fall back to the global only if no row matches — enabling 1-printer-per-
user setups (e.g. four SATO WS4s across four operators) without
disturbing existing single-printer installations.

The user_printer_defaults table is gated behind the toggle in the UI so
admins don't see it unless the feature is enabled.

Six call sites in api/mes_ops.py and page/storekeeper_hub/storekeeper_hub.py
were migrated from getattr(fs, "default_label_printer", None) to
get_label_printer(fs); the helper's _per_user_enabled accepts only real
bool/int/str values so MagicMock-based unit tests can't accidentally
flip into per-user mode.