### PR TITLE
Enhance operator hub with current WO highlighting and planned dates

### DIFF
--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -1026,6 +1026,7 @@ def get_line_queue(line: Optional[str] = None, lines: Optional[str] = None):
                 "item_name": wo.item_name,
                 "type": "FG" if _is_fg(wo.production_item) else "SF",
                 "custom_production_ended": wo.get("custom_production_ended", 0),
+                "planned_start_date": wo.get("planned_start_date"),
             }
         )
     return out

--- a/isnack/isnack/page/operator_hub/operator_hub.css
+++ b/isnack/isnack/page/operator_hub/operator_hub.css
@@ -200,6 +200,15 @@
 .op-teal .chip-partial{ background:#fef3c7; color:#92400e; border-color:#fde68a; }
 .op-teal .chip-not-allocated{ background:#f3f4f6; color:#6b7280; border-color:#e5e7eb; }
 .op-teal .chip-ended{ background:#1f2937; color:#f9fafb; border-color:#111827; }
+.op-teal .row-current{
+  background:var(--teal-soft);
+  border-color:var(--teal);
+  box-shadow:inset 3px 0 0 var(--teal);
+}
+.op-teal .row-current:hover{
+  background:var(--teal-soft);
+  border-color:var(--teal);
+}
 .op-teal .row-ended{ opacity:.65; }
 .op-teal .row-ended .fw-semibold{ text-decoration: line-through; text-decoration-color: #6b7280; }
 

--- a/isnack/isnack/page/operator_hub/operator_hub.js
+++ b/isnack/isnack/page/operator_hub/operator_hub.js
@@ -645,7 +645,11 @@ function init_operator_hub($root) {
       }[row.status] || 'chip chip-ns');
       const isEnded = !!row.custom_production_ended;
       const endedChip = isEnded ? '<span class="chip chip-ended" title="Production ended — awaiting Close Production">Ended</span>' : '';
-      const rowClass = isEnded ? ' row-ended' : '';
+      const isCurrent = row.name === state.current_wo;
+      const rowClass = `${isEnded ? ' row-ended' : ''}${isCurrent ? ' row-current' : ''}`;
+      const plannedDate = row.planned_start_date
+        ? `<span class="text-muted ms-2">Planned ${frappe.utils.escape_html(frappe.datetime.global_date_format(row.planned_start_date))}</span>`
+        : '';
       const el = $(`
         <button class="list-group-item list-group-item-action py-3 d-flex justify-content-between align-items-center${rowClass}" type="button">
           <div class="fw-semibold">
@@ -653,6 +657,7 @@ function init_operator_hub($root) {
             <span class="text-muted">— ${frappe.utils.escape_html(row.item_name || '')}</span>
             <span class="text-muted ms-2">Qty ${row.for_quantity}</span>
             ${row.line ? `<span class="text-muted ms-2">Line ${frappe.utils.escape_html(row.line)}</span>` : ''}
+            ${plannedDate}
           </div>
           <div class="d-flex gap-2 align-items-center">
             <span class="${chipType}">${row.type}</span>
@@ -662,6 +667,7 @@ function init_operator_hub($root) {
           </div>
         </button>
       `);
+      el.attr('data-wo', row.name);
       el.on('click', () => set_active_work_order(row.name)); grid.append(el);
     });
   }
@@ -673,6 +679,10 @@ function init_operator_hub($root) {
     state.current_wo_status = row ? row.status : null;
     state.current_stage_status = row ? row.stage_status : null;
     state.current_production_ended = row ? (row.custom_production_ended || false) : false;
+
+    grid.children('.list-group-item').removeClass('row-current')
+      .filter(function () { return $(this).attr('data-wo') === wo_name; })
+      .addClass('row-current');
 
     rpc('isnack.api.mes_ops.get_wo_banner', { work_order: wo_name })
       .then(r => banner.html(r.message && r.message.html ? r.message.html : '—'));


### PR DESCRIPTION
## Summary
This PR improves the operator hub UI by visually highlighting the currently active work order and displaying planned start dates for each work order in the queue.

## Key Changes
- **Current work order highlighting**: Added visual distinction for the active work order with a teal background, border, and left accent bar
  - Implemented `row-current` CSS class with appropriate styling for the teal theme
  - Added logic to track and update the current work order row styling when selection changes
  - Added `data-wo` attribute to work order elements for efficient DOM querying

- **Planned start date display**: Added planned start date information to work order list items
  - Fetches `planned_start_date` from work order data in the backend
  - Displays formatted date in a muted text style next to quantity information
  - Properly escapes HTML to prevent injection vulnerabilities

- **Backend data enhancement**: Extended `get_line_queue()` API response to include `planned_start_date` field

## Implementation Details
- The current work order highlighting uses a filter-based approach to efficiently update styling when the active work order changes
- Date formatting leverages Frappe's built-in `frappe.datetime.global_date_format()` utility
- All user-facing text is properly escaped using `frappe.utils.escape_html()` for security
- CSS styling maintains consistency with existing operator hub theme variables

https://claude.ai/code/session_01YQ2ifkv2QhWkZzkGjMs1aj