### PR TITLE
feat: add fill-from-available actions to End Shift Return

### DIFF
--- a/isnack/isnack/page/operator_hub/operator_hub.css
+++ b/isnack/isnack/page/operator_hub/operator_hub.css
@@ -808,6 +808,34 @@
   opacity: 1;
 }
 
+/* Per-row fill button — teal mirror of the clear button */
+.end-shift-return-dialog .wip-row-fill-btn{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 1px solid #b8f1e6;
+  background: #e7fbf7;
+  color: #0f766e;
+  font-size: .75rem;
+  line-height: 1;
+  cursor: pointer;
+  margin-left: 4px;
+  opacity: 0;
+  transition: opacity .15s ease, background .12s ease;
+  vertical-align: middle;
+  padding: 0;
+}
+.end-shift-return-dialog .wip-return-table tr:hover .wip-row-fill-btn{
+  opacity: 1;
+}
+.end-shift-return-dialog .wip-row-fill-btn:hover{
+  background: #c8f6ed !important;
+  opacity: 1;
+}
+
 /* Batch pill badges */
 .end-shift-return-dialog .batch-badge{
   display: inline-block;
@@ -874,6 +902,26 @@
   background: #fee2e2 !important;
 }
 
+/* "Fill Selected" button — teal-outline mirror of Clear Selected */
+.end-shift-return-dialog .wip-fill-selected-btn{
+  display: none;
+  background: #e7fbf7 !important;
+  border-color: #b8f1e6 !important;
+  color: #0f766e !important;
+  font-size: .82rem;
+  padding: .25rem .65rem;
+  border-radius: 8px;
+  border: 1px solid;
+  cursor: pointer;
+  transition: opacity .2s ease, background .12s ease;
+}
+.end-shift-return-dialog .wip-fill-selected-btn.visible{
+  display: inline-block;
+}
+.end-shift-return-dialog .wip-fill-selected-btn:hover{
+  background: #c8f6ed !important;
+}
+
 /* Post Return button — teal CTA is provided by .op-dialog. */
 
 /* Summary footer */
@@ -896,7 +944,9 @@
 @media (prefers-reduced-motion: reduce){
   .end-shift-return-dialog .wip-return-table tbody tr,
   .end-shift-return-dialog .wip-row-clear-btn,
-  .end-shift-return-dialog .wip-clear-selected-btn{
+  .end-shift-return-dialog .wip-row-fill-btn,
+  .end-shift-return-dialog .wip-clear-selected-btn,
+  .end-shift-return-dialog .wip-fill-selected-btn{
     transition: none !important;
     animation: none !important;
   }

--- a/isnack/isnack/page/operator_hub/operator_hub.js
+++ b/isnack/isnack/page/operator_hub/operator_hub.js
@@ -1370,6 +1370,7 @@ function init_operator_hub($root) {
       // Build table HTML for WIP items
       const tableHTML = `
         <div class="wip-toolbar">
+          <button type="button" class="wip-fill-selected-btn">⤓ Fill Selected</button>
           <button type="button" class="wip-clear-selected-btn">✕ Clear Selected</button>
         </div>
         <div class="table-responsive" style="max-height:400px; overflow:auto;">
@@ -1487,6 +1488,7 @@ function init_operator_hub($root) {
             <td class="col-avail-qty">${item.qty}</td>
             <td style="white-space:nowrap;">
               <input type="number" class="form-control form-control-sm return-qty-input" value="0" min="0" max="${item.qty}" step="0.01" data-avail="${item.qty}">
+              <button type="button" class="wip-row-fill-btn" title="Fill available qty">⤓</button>
               <button type="button" class="wip-row-clear-btn" title="Clear">✕</button>
             </td>
             <td>${batchBadge}</td>
@@ -1511,29 +1513,35 @@ function init_operator_hub($root) {
         d.$wrapper.find('#wip-sum-total').text(total.toFixed(2));
       }
 
+      // Helper: show/hide the bulk Selected-row action buttons
+      function toggleSelectedActions() {
+        const anyChecked = $tbody.find('.wip-row-check:checked').length > 0;
+        d.$wrapper.find('.wip-clear-selected-btn, .wip-fill-selected-btn')
+          .toggleClass('visible', anyChecked);
+      }
+
       // Wire up event handlers
       // Select-all checkbox
       d.$wrapper.find('#wip-select-all').on('change', function () {
-        const checked = this.checked;
-        $tbody.find('.wip-row-check').prop('checked', checked);
-        const $btn = d.$wrapper.find('.wip-clear-selected-btn');
-        if (checked && $tbody.find('.wip-row-check').length) {
-          $btn.addClass('visible');
-        } else {
-          $btn.removeClass('visible');
-        }
+        $tbody.find('.wip-row-check').prop('checked', this.checked);
+        toggleSelectedActions();
       });
 
-      // Row check → show/hide Clear Selected button
+      // Row check → show/hide bulk Selected-row action buttons
       $tbody.on('change', '.wip-row-check', function () {
-        const anyChecked = $tbody.find('.wip-row-check:checked').length > 0;
-        const $btn = d.$wrapper.find('.wip-clear-selected-btn');
-        if (anyChecked) {
-          $btn.addClass('visible');
-        } else {
-          $btn.removeClass('visible');
+        if (!$tbody.find('.wip-row-check:checked').length) {
           d.$wrapper.find('#wip-select-all').prop('checked', false);
         }
+        toggleSelectedActions();
+      });
+
+      // Fill Selected button → set checked rows' return qty to available qty
+      d.$wrapper.find('.wip-fill-selected-btn').on('click', function () {
+        $tbody.find('.wip-row-check:checked').each((_, chk) => {
+          const $input = $(chk).closest('tr').find('.return-qty-input');
+          $input.val($input.data('avail'));
+        });
+        updateWipSummary();
       });
 
       // Clear Selected button
@@ -1543,7 +1551,14 @@ function init_operator_hub($root) {
           $(chk).prop('checked', false);
         });
         d.$wrapper.find('#wip-select-all').prop('checked', false);
-        $(this).removeClass('visible');
+        toggleSelectedActions();
+        updateWipSummary();
+      });
+
+      // Per-row fill button → set return qty to available qty
+      $tbody.on('click', '.wip-row-fill-btn', function () {
+        const $input = $(this).closest('tr').find('.return-qty-input');
+        $input.val($input.data('avail'));
         updateWipSummary();
       });
 


### PR DESCRIPTION
Add a per-row Max button that sets a row's return qty to its available qty, and a Fill Selected toolbar button that does the same for all checked rows, mirroring the existing clear actions.

https://claude.ai/code/session_01YQ2ifkv2QhWkZzkGjMs1aj