### PR TITLE
fix(storekeeper_hub): exclude started Work Orders from Generate Picklist

### DIFF
--- a/isnack/isnack/page/storekeeper_hub/storekeeper_hub.py
+++ b/isnack/isnack/page/storekeeper_hub/storekeeper_hub.py
@@ -822,7 +822,11 @@ def get_recent_transfers(
     hours" based on se.modified.
     """
     factory_line = _normalize_factory_line(factory_line)
-    joins = ["left join `tabWork Order` wo on wo.name = se.work_order"]
+    joins = [
+        "left join `tabWork Order` wo on wo.name = se.work_order",
+        # Originating WO for surplus SEs (which have no direct work_order link).
+        "left join `tabWork Order` owo on owo.name = se.custom_originating_work_order",
+    ]
     # Picklist source: Stores → Staging transfers only. 'Material Transfer for
     # Manufacture' is the downstream Staging → WIP movement created by the
     # operator Start action and is not what the storekeeper picks.
@@ -834,6 +838,12 @@ def get_recent_transfers(
         "se.docstatus = 1",
         "se.purpose = 'Material Transfer'",
         "(se.work_order IS NOT NULL OR se.custom_is_surplus = 1)",
+        # Exclude anything tied to a WO that has already started from the
+        # Operator Hub (actual_start_date is set on the Start action and is
+        # never cleared, so it survives later Pause/Stop). This covers both
+        # WO-linked SEs (via wo) and surplus SEs (via their originating owo).
+        "wo.actual_start_date IS NULL",
+        "owo.actual_start_date IS NULL",
     ]
     params: list[object] = []
 

--- a/isnack/isnack/page/storekeeper_hub/test_storekeeper_hub.py
+++ b/isnack/isnack/page/storekeeper_hub/test_storekeeper_hub.py
@@ -461,6 +461,22 @@ class TestGetRecentTransfers(unittest.TestCase):
         self.assertIn("se.modified >= %s", query)
         self.assertEqual(len(params), 1)
 
+    @patch("isnack.isnack.page.storekeeper_hub.storekeeper_hub.add_to_date", return_value="2026-05-28 00:00:00")
+    @patch("isnack.isnack.page.storekeeper_hub.storekeeper_hub.now_datetime", return_value="2026-05-28 12:00:00")
+    @patch("frappe.db.sql")
+    def test_excludes_stock_entries_for_started_work_orders(self, mock_sql, _now_datetime, _add_to_date):
+        mock_sql.side_effect = [[], []]
+
+        get_recent_transfers(posting_date=None)
+
+        query = mock_sql.call_args_list[0][0][0]
+        # WO-linked SEs whose Work Order has already started are filtered out.
+        self.assertIn("wo.actual_start_date IS NULL", query)
+        # Surplus SEs are joined to their originating Work Order and excluded
+        # once that originating WO has started.
+        self.assertIn("owo.name = se.custom_originating_work_order", query)
+        self.assertIn("owo.actual_start_date IS NULL", query)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Generate Picklist (get_recent_transfers) was still listing Stock Entries tied to Work Orders already started from the Operator Hub, including surplus Stock Entries whose originating Work Order had started.

Filter both out by joining the originating Work Order for surplus entries and excluding any row whose WO (or originating WO) has actual_start_date set. actual_start_date is written on the Start action and never cleared, so the exclusion survives later Pause/Stop.

https://claude.ai/code/session_01QiGUrKUKKfj4vrnnsXX5FL