### PR TITLE
Override Packing Slip weight calculations to use net weight field

### DIFF
--- a/isnack/hooks.py
+++ b/isnack/hooks.py
@@ -143,6 +143,7 @@ override_doctype_class = {
     "Journal Entry": "isnack.overrides.journal_entry.CustomJournalEntry",
     "Payment Reconciliation": "isnack.overrides.payment_reconciliation.CustomPaymentReconciliation",
     "Landed Cost Voucher": "isnack.overrides.landed_cost_voucher.CustomLandedCostVoucher",
+    "Packing Slip": "isnack.overrides.packing_slip.CustomPackingSlip",
 }
 
 # Document Events

--- a/isnack/overrides/packing_slip.py
+++ b/isnack/overrides/packing_slip.py
@@ -1,0 +1,66 @@
+"""Packing Slip weight calculation override.
+
+The Item master stores three weight fields:
+
+    custom_net_weight_per_unit  -- net weight of the goods
+    custom_tare_weight_per_unit -- packaging (tare) weight
+    weight_per_unit             -- kept in sync as net + tare (i.e. GROSS)
+                                   by ``isnack.overrides.item.sync_weight_per_unit``
+
+Stock ERPNext populates Packing Slip Item ``net_weight`` from the Item's
+``weight_per_unit``, which here is the *gross* weight. That makes the package
+Net Weight equal the Gross Weight. This override sources the per-item net
+weight from ``custom_net_weight_per_unit`` and always derives the package
+gross weight from ``weight_per_unit`` (net + tare).
+"""
+
+from __future__ import annotations
+
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+from erpnext.stock.doctype.packing_slip.packing_slip import PackingSlip
+
+
+class CustomPackingSlip(PackingSlip):
+    def set_missing_values(self):
+        if not self.from_case_no:
+            self.from_case_no = self.get_recommended_case_no()
+
+        for item in self.items:
+            net_weight_per_unit, weight_per_unit, weight_uom = frappe.db.get_value(
+                "Item",
+                item.item_code,
+                ["custom_net_weight_per_unit", "weight_per_unit", "weight_uom"],
+            )
+            default_net = flt(net_weight_per_unit) or flt(weight_per_unit)
+            if default_net and not item.net_weight:
+                item.net_weight = default_net
+            if weight_uom and not item.weight_uom:
+                item.weight_uom = weight_uom
+
+    def calculate_net_total_pkg(self):
+        self.net_weight_uom = self.items[0].weight_uom if self.items else None
+        self.gross_weight_uom = self.net_weight_uom
+
+        net_weight_pkg = 0
+        gross_weight_pkg = 0
+        for item in self.items:
+            if item.weight_uom != self.net_weight_uom:
+                frappe.throw(
+                    _(
+                        "Different UOM for items will lead to incorrect (Total) Net "
+                        "Weight value. Make sure that Net Weight of each item is in "
+                        "the same UOM."
+                    )
+                )
+
+            net_weight_pkg += flt(item.net_weight) * flt(item.qty)
+            gross_weight_per_unit = frappe.db.get_value(
+                "Item", item.item_code, "weight_per_unit"
+            )
+            gross_weight_pkg += flt(gross_weight_per_unit) * flt(item.qty)
+
+        self.net_weight_pkg = round(net_weight_pkg, 2)
+        self.gross_weight_pkg = round(gross_weight_pkg, 2)

--- a/isnack/overrides/test_packing_slip.py
+++ b/isnack/overrides/test_packing_slip.py
@@ -1,0 +1,57 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from isnack.overrides.packing_slip import CustomPackingSlip
+
+
+# Item master weight values keyed by item_code, mirroring the synced
+# weight_per_unit (= net + tare) maintained by isnack.overrides.item.
+ITEM_WEIGHTS = {
+    "FG10002": {
+        "custom_net_weight_per_unit": 0.840,
+        "weight_per_unit": 1.170,
+        "weight_uom": "Kg",
+    },
+}
+
+
+def _fake_get_value(doctype, item_code, fields):
+    data = ITEM_WEIGHTS[item_code]
+    if isinstance(fields, str):
+        return data[fields]
+    return [data[f] for f in fields]
+
+
+class TestPackingSlipWeights(unittest.TestCase):
+    def _make_slip(self, items):
+        slip = CustomPackingSlip.__new__(CustomPackingSlip)
+        slip.items = [SimpleNamespace(**item) for item in items]
+        slip.from_case_no = 1
+        return slip
+
+    def test_net_weight_uses_custom_net_weight_per_unit(self):
+        slip = self._make_slip(
+            [{"item_code": "FG10002", "qty": 250, "net_weight": None, "weight_uom": None}]
+        )
+        with patch("isnack.overrides.packing_slip.frappe.db.get_value", _fake_get_value):
+            slip.set_missing_values()
+            slip.calculate_net_total_pkg()
+
+        self.assertEqual(slip.items[0].net_weight, 0.840)
+        self.assertEqual(slip.net_weight_pkg, 210.00)
+        self.assertEqual(slip.gross_weight_pkg, 292.50)
+
+    def test_gross_always_recomputed_from_weight_per_unit(self):
+        slip = self._make_slip(
+            [{"item_code": "FG10002", "qty": 250, "net_weight": 0.840, "weight_uom": "Kg"}]
+        )
+        slip.gross_weight_pkg = 999.0
+        with patch("isnack.overrides.packing_slip.frappe.db.get_value", _fake_get_value):
+            slip.calculate_net_total_pkg()
+
+        self.assertEqual(slip.gross_weight_pkg, 292.50)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR adds a custom Packing Slip implementation that corrects weight calculations to distinguish between net and gross weights. The standard ERPNext behavior incorrectly uses the gross weight (net + tare) for the net weight field. This override sources per-item net weights from the Item master's `custom_net_weight_per_unit` field while deriving gross weights from `weight_per_unit`.

## Key Changes
- **New override module** (`isnack/overrides/packing_slip.py`): Implements `CustomPackingSlip` class that:
  - Populates item net weights from `custom_net_weight_per_unit` instead of the gross `weight_per_unit`
  - Recalculates package gross weight from the Item master's `weight_per_unit` field (which is maintained as net + tare by the item override)
  - Validates that all items use the same weight UOM
  - Properly sets missing weight UOM values from the Item master

- **Comprehensive test suite** (`isnack/overrides/test_packing_slip.py`): Validates:
  - Net weight is sourced from `custom_net_weight_per_unit`
  - Gross weight is always recomputed from `weight_per_unit` (not cached)
  - Correct totals are calculated for package-level weights

- **Hook registration** (`isnack/hooks.py`): Registers the custom Packing Slip class to override the standard ERPNext implementation

## Implementation Details
The override leverages the existing weight synchronization maintained by `isnack.overrides.item.sync_weight_per_unit`, which keeps `weight_per_unit = custom_net_weight_per_unit + custom_tare_weight_per_unit`. This ensures gross weight calculations are always accurate and consistent with the Item master data.

https://claude.ai/code/session_01YQ4Ytgij4h8t7ZhYyKn2d6