### PR TITLE
feat: filter Production Plan Assembly Items by configurable item group

### DIFF
--- a/isnack/isnack/doctype/factory_settings/factory_settings.json
+++ b/isnack/isnack/doctype/factory_settings/factory_settings.json
@@ -25,6 +25,9 @@
   "per_line_rules_section",
   "default_semi_finished_warehouse",
   "line_warehouse_map",
+  "production_plan_section",
+  "production_assembly_item_group",
+  "default_finished_goods_warehouse",
   "label_printing_section",
   "default_label_template",
   "default_label_print_format",
@@ -160,6 +163,25 @@
    "fieldtype": "Table MultiSelect",
    "label": "Allowed Item Groups",
    "options": "Line Allowed Item Groups"
+  },
+  {
+   "fieldname": "production_plan_section",
+   "fieldtype": "Section Break",
+   "label": "Production Plan"
+  },
+  {
+   "description": "Item Group used to filter items in the Assembly Items table of a Production Plan.",
+   "fieldname": "production_assembly_item_group",
+   "fieldtype": "Link",
+   "label": "Production Assembly Item Group",
+   "options": "Item Group"
+  },
+  {
+   "description": "Default warehouse set as the Finished Goods (For Warehouse) on new Assembly Items rows of a Production Plan.",
+   "fieldname": "default_finished_goods_warehouse",
+   "fieldtype": "Link",
+   "label": "Default Finished Goods Warehouse",
+   "options": "Warehouse"
   },
   {
    "fieldname": "label_printing_section",

--- a/isnack/public/js/production_plan.js
+++ b/isnack/public/js/production_plan.js
@@ -1,6 +1,27 @@
 frappe.ui.form.off("Production Plan", "make_work_order");
 
 frappe.ui.form.on("Production Plan", {
+  setup(frm) {
+    // Restrict Assembly Items to the configured Production Assembly Item Group.
+    frm.set_query("item_code", "po_items", () => {
+      if (frm.__isnack_assembly_item_group) {
+        return { filters: { item_group: frm.__isnack_assembly_item_group } };
+      }
+      return {};
+    });
+  },
+
+  onload(frm) {
+    isnack_load_production_plan_defaults(frm);
+  },
+
+  po_items_add(frm, cdt, cdn) {
+    // Default the Finished Goods (For Warehouse) on new Assembly Items rows.
+    if (frm.__isnack_default_fg_warehouse) {
+      frappe.model.set_value(cdt, cdn, "warehouse", frm.__isnack_default_fg_warehouse);
+    }
+  },
+
   refresh(frm) {
     if (!frm.doc.__islocal) {
       frm.add_custom_button(
@@ -79,6 +100,23 @@ frappe.ui.form.on("Production Plan", {
     });
   },
 });
+
+// Load Production Plan defaults from Factory Settings and cache them on the
+// form so the Assembly Items item-group filter and Finished Goods Warehouse
+// default can be applied without an extra round trip per row/lookup.
+async function isnack_load_production_plan_defaults(frm) {
+  try {
+    const [item_group, fg_warehouse] = await Promise.all([
+      frappe.db.get_single_value("Factory Settings", "production_assembly_item_group"),
+      frappe.db.get_single_value("Factory Settings", "default_finished_goods_warehouse"),
+    ]);
+    frm.__isnack_assembly_item_group = item_group || null;
+    frm.__isnack_default_fg_warehouse = fg_warehouse || null;
+  } catch (e) {
+    frm.__isnack_assembly_item_group = null;
+    frm.__isnack_default_fg_warehouse = null;
+  }
+}
 
 // Pallet-label reprint dialog for a Production Plan's closed Work Orders.
 // Self-contained (not shared with the Operator Hub dialog) and read-only —


### PR DESCRIPTION
Add a "Production Plan" section to Factory Settings with two settings:
- Production Assembly Item Group: filters items in the Assembly Items (po_items) table of a Production Plan.
- Default Finished Goods Warehouse: defaulted onto the For Warehouse field of new Assembly Items rows.

https://claude.ai/code/session_019VScAZ1U9ceDuWvo963UuV