### PR TITLE
fix: read Production Plan defaults via permission-safe server method

### DIFF
--- a/isnack/overrides/production_plan.py
+++ b/isnack/overrides/production_plan.py
@@ -29,6 +29,26 @@ from erpnext.utilities.transaction_base import validate_uom_is_integer
 
 from erpnext.manufacturing.doctype.production_plan.production_plan import ProductionPlan, get_sub_assembly_items, get_bin_details
 
+
+@frappe.whitelist()
+def get_production_plan_defaults():
+    """Return Production Plan defaults from Factory Settings.
+
+    Read here (server-side) rather than client-side because Factory Settings
+    is only readable by System Manager; Production Plan users would otherwise
+    get a permission error and the Assembly Items filter/warehouse default
+    would silently do nothing.
+    """
+    return {
+        "assembly_item_group": frappe.db.get_single_value(
+            "Factory Settings", "production_assembly_item_group"
+        ),
+        "default_finished_goods_warehouse": frappe.db.get_single_value(
+            "Factory Settings", "default_finished_goods_warehouse"
+        ),
+    }
+
+
 class CustomProductionPlan(ProductionPlan):
     def before_save(self):
         #    This method will populate the 'total_estimated_cost' field.

--- a/isnack/public/js/production_plan.js
+++ b/isnack/public/js/production_plan.js
@@ -104,18 +104,17 @@ frappe.ui.form.on("Production Plan", {
 // Load Production Plan defaults from Factory Settings and cache them on the
 // form so the Assembly Items item-group filter and Finished Goods Warehouse
 // default can be applied without an extra round trip per row/lookup.
-async function isnack_load_production_plan_defaults(frm) {
-  try {
-    const [item_group, fg_warehouse] = await Promise.all([
-      frappe.db.get_single_value("Factory Settings", "production_assembly_item_group"),
-      frappe.db.get_single_value("Factory Settings", "default_finished_goods_warehouse"),
-    ]);
-    frm.__isnack_assembly_item_group = item_group || null;
-    frm.__isnack_default_fg_warehouse = fg_warehouse || null;
-  } catch (e) {
-    frm.__isnack_assembly_item_group = null;
-    frm.__isnack_default_fg_warehouse = null;
-  }
+// Uses a whitelisted server method because Factory Settings is only readable
+// by System Manager; a direct client read would be denied for planners.
+function isnack_load_production_plan_defaults(frm) {
+  frappe.call({
+    method: "isnack.overrides.production_plan.get_production_plan_defaults",
+    callback(r) {
+      const d = (r && r.message) || {};
+      frm.__isnack_assembly_item_group = d.assembly_item_group || null;
+      frm.__isnack_default_fg_warehouse = d.default_finished_goods_warehouse || null;
+    },
+  });
 }
 
 // Pallet-label reprint dialog for a Production Plan's closed Work Orders.


### PR DESCRIPTION
Factory Settings is only readable by System Manager, so reading production_assembly_item_group / default_finished_goods_warehouse directly from the client was denied for non-admin planners, leaving the Assembly Items filter and warehouse default as silent no-ops. Fetch both values via a whitelisted server method instead.

https://claude.ai/code/session_019VScAZ1U9ceDuWvo963UuV