### PR TITLE
fix: default FG warehouse on po_items via item_code child event

### DIFF
--- a/isnack/public/js/production_plan.js
+++ b/isnack/public/js/production_plan.js
@@ -103,6 +103,17 @@ frappe.ui.form.on("Production Plan", {
   },
 });
 
+frappe.ui.form.on("Production Plan Item", {
+  // Default the Finished Goods (For Warehouse) when an item is chosen. This
+  // covers the pre-rendered first row, which never fires po_items_add.
+  item_code(frm, cdt, cdn) {
+    const row = locals[cdt][cdn];
+    if (frm.__isnack_default_fg_warehouse && !row.warehouse) {
+      frappe.model.set_value(cdt, cdn, "warehouse", frm.__isnack_default_fg_warehouse);
+    }
+  },
+});
+
 // Load Production Plan defaults from Factory Settings and cache them on the
 // form so the Assembly Items item-group filter and Finished Goods Warehouse
 // default can be applied without an extra round trip per row/lookup.


### PR DESCRIPTION
po_items_add only fires for rows created via the Add Row button, not the pre-rendered first row, so the warehouse default was skipped there. Add a Production Plan Item item_code handler that sets the warehouse when empty, covering every row. ERPNext's get_item_data returns no warehouse key, so this does not conflict.

https://claude.ai/code/session_019VScAZ1U9ceDuWvo963UuV