### PR TITLE
fix(operator-hub): make pallet Split a clickable inline icon

### DIFF
--- a/isnack/isnack/page/operator_hub/operator_hub.js
+++ b/isnack/isnack/page/operator_hub/operator_hub.js
@@ -1966,22 +1966,18 @@ function init_operator_hub($root) {
               columns: 1,
             },
             {
-              fieldname: 'split_btn',
-              fieldtype: 'Button',
-              label: 'Split…',
-              in_list_view: 1,
-              columns: 1,
-              click: function () {
-                showSplitDialog(this.grid_row);
-              }
-            },
-            {
               fieldname: 'splits_summary',
               fieldtype: 'Data',
               label: 'Split',
               in_list_view: 1,
               read_only: 1,
-              columns: 2,
+              columns: 3,
+              formatter: function (value) {
+                const safe = value ? frappe.utils.escape_html(value) : '';
+                const icon = `<button type="button" class="btn btn-xs btn-default isn-split-btn" title="Split across pallet types" style="padding:1px 6px;margin-right:6px;line-height:1;"><svg class="icon icon-sm" style="vertical-align:middle;"><use href="#icon-branch"></use></svg></button>`;
+                const text = safe ? `<span style="color:#555;">${safe}</span>` : '';
+                return icon + text;
+              }
             },
             {
               fieldname: 'work_orders',
@@ -2114,6 +2110,32 @@ function init_operator_hub($root) {
       });
     });
     d.fields_dict.pallet_items.grid.refresh();
+
+    // Delegated click handler for the inline split icon. Frappe v15 grid
+    // Button fields don't fire `click` reliably, so we render the icon via
+    // the splits_summary formatter and bind here.
+    d.$wrapper.off('click.isnSplit').on('click.isnSplit', '.isn-split-btn', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      const $row = $(this).closest('[data-name], .grid-row');
+      const dataName = $row.attr('data-name');
+      const dataIdx = $row.attr('data-idx');
+      const grid = d.fields_dict.pallet_items.grid;
+      const rows = grid.grid_rows || [];
+      let gridRow = null;
+      if (dataName) {
+        gridRow = rows.find(gr => gr.doc && gr.doc.name === dataName);
+      }
+      if (!gridRow && dataIdx) {
+        const idxNum = parseInt(dataIdx, 10);
+        gridRow = rows.find(gr => gr.doc && parseInt(gr.doc.idx, 10) === idxNum);
+      }
+      if (gridRow) {
+        showSplitDialog(gridRow);
+      } else {
+        console.warn('Split: could not resolve grid row', dataName, dataIdx);
+      }
+    });
 
     d.show();
   }


### PR DESCRIPTION
Frappe v15 grid Button fields render but don't invoke the field's click handler, so the previous "Split…" button did nothing. Replace it with a small icon rendered inside the Split column via the cell formatter, and wire clicks through a delegated handler on the dialog wrapper that resolves the originating grid row by data-name / data-idx.

Also frees a grid column: removes the dedicated Button column and lets the Split column carry both the icon and the allocation summary.