### PR TITLE
feat(delivery-note): auto-print packing slips to A4 network printer

### DIFF
--- a/isnack/api/delivery_note_packing_slips.py
+++ b/isnack/api/delivery_note_packing_slips.py
@@ -31,6 +31,8 @@ import frappe
 from frappe import _
 from frappe.utils import cint, flt, now_datetime
 
+from isnack.utils.printing import enqueue_doc_print
+
 # Deterministic group key for Delivery Note rows that have no Sales Order.
 # Used only for the idempotency reference string -- never written into the
 # `custom_sales_order` Link field.
@@ -274,5 +276,16 @@ def _create_and_submit_packing_slip(doc, group_key: str, group: dict, case_no: i
         item.packed_qty = flt(item.get("qty"))
     for packed_item in group["packed_items"]:
         packed_item.packed_qty = flt(packed_item.get("qty"))
+
+    # Send the submitted Packing Slip to the configured A4 Network Printer.
+    # Printing failures must never break Delivery Note submission, so the call
+    # is best-effort and only logs on error.
+    try:
+        enqueue_doc_print("Packing Slip", ps.name)
+    except Exception:
+        frappe.log_error(
+            title="Auto Packing Slip Print Enqueue Failed",
+            message=frappe.get_traceback(),
+        )
 
     return ps.name

--- a/isnack/api/test_delivery_note_packing_slips.py
+++ b/isnack/api/test_delivery_note_packing_slips.py
@@ -187,11 +187,12 @@ class TestCheckExistingPackingSlips(unittest.TestCase):
 class TestCreateAndSubmitPackingSlip(unittest.TestCase):
     """Per-group Packing Slip creation, field mapping and packed_qty mirroring."""
 
+    @patch.object(dnps, "enqueue_doc_print")
     @patch("isnack.api.delivery_note_packing_slips.now_datetime",
            return_value="2026-05-22 10:00:00")
     @patch("isnack.api.delivery_note_packing_slips.frappe.new_doc")
     def test_pallet_fields_copied_and_packed_qty_mirrored(
-        self, mock_new_doc, _now
+        self, mock_new_doc, _now, mock_enqueue
     ):
         ps = _FakePackingSlip()
         mock_new_doc.return_value = ps
@@ -228,10 +229,14 @@ class TestCreateAndSubmitPackingSlip(unittest.TestCase):
         # is persisted and the standard validate_packed_qty check passes.
         self.assertEqual(dn_item.packed_qty, 2000)
 
+        # The submitted Packing Slip is dispatched to the A4 printer.
+        mock_enqueue.assert_called_once_with("Packing Slip", ps.name)
+
+    @patch.object(dnps, "enqueue_doc_print")
     @patch("isnack.api.delivery_note_packing_slips.now_datetime",
            return_value="2026-05-22 10:00:00")
     @patch("isnack.api.delivery_note_packing_slips.frappe.new_doc")
-    def test_no_sales_order_group_leaves_link_blank(self, mock_new_doc, _now):
+    def test_no_sales_order_group_leaves_link_blank(self, mock_new_doc, _now, _enqueue):
         ps = _FakePackingSlip()
         mock_new_doc.return_value = ps
 
@@ -249,10 +254,35 @@ class TestCreateAndSubmitPackingSlip(unittest.TestCase):
             ps.custom_auto_creation_reference, "DN-0001|NO-SALES-ORDER"
         )
 
+    @patch("isnack.api.delivery_note_packing_slips.frappe.log_error")
+    @patch.object(dnps, "enqueue_doc_print",
+                  side_effect=RuntimeError("printer module missing"))
     @patch("isnack.api.delivery_note_packing_slips.now_datetime",
            return_value="2026-05-22 10:00:00")
     @patch("isnack.api.delivery_note_packing_slips.frappe.new_doc")
-    def test_packed_item_row_uses_pi_detail(self, mock_new_doc, _now):
+    def test_print_enqueue_failure_does_not_break_submission(
+        self, mock_new_doc, _now, _enqueue, mock_log_error
+    ):
+        ps = _FakePackingSlip()
+        mock_new_doc.return_value = ps
+
+        dn_item = _dn_item("r1", "FG10005", 5, "SO-0001")
+        dn = _FakeDN(items=[dn_item])
+        group = {"sales_order": "SO-0001", "dn_items": [dn_item], "packed_items": []}
+
+        # The Packing Slip is still returned and packed_qty mirrored even though
+        # the print enqueue blew up; the failure is just logged.
+        name = dnps._create_and_submit_packing_slip(dn, "SO-0001", group, 1)
+        self.assertEqual(name, ps.name)
+        self.assertTrue(ps.submitted)
+        self.assertEqual(dn_item.packed_qty, 5)
+        mock_log_error.assert_called_once()
+
+    @patch.object(dnps, "enqueue_doc_print")
+    @patch("isnack.api.delivery_note_packing_slips.now_datetime",
+           return_value="2026-05-22 10:00:00")
+    @patch("isnack.api.delivery_note_packing_slips.frappe.new_doc")
+    def test_packed_item_row_uses_pi_detail(self, mock_new_doc, _now, _enqueue):
         ps = _FakePackingSlip()
         mock_new_doc.return_value = ps
 

--- a/isnack/utils/printing.py
+++ b/isnack/utils/printing.py
@@ -1,6 +1,9 @@
 import frappe
 from frappe.utils import cstr
 
+# Fallback print format when no DocType-level default is configured.
+DEFAULT_FALLBACK_PRINT_FORMAT = "Standard"
+
 
 def get_factory_settings():
     try:
@@ -104,3 +107,44 @@ def get_a4_printer(fs=None) -> str | None:
         return frappe.db.get_single_value("Print Settings", "default_printer")
     except Exception:
         return None
+
+
+def _doctype_default_print_format(doctype: str) -> str:
+    """Return the DocType's configured default Print Format, or a sane fallback.
+
+    Respects any Property Setter override (e.g. the
+    ``Packing Slip-main-default_print_format`` fixture) since the meta lookup
+    reads from the same column.
+    """
+    try:
+        value = frappe.db.get_value("DocType", doctype, "default_print_format")
+    except Exception:
+        value = None
+    return cstr(value) if value else DEFAULT_FALLBACK_PRINT_FORMAT
+
+
+def enqueue_doc_print(doctype: str, name: str, printer: str | None = None,
+                      print_format: str | None = None) -> bool:
+    """Enqueue a background job that prints a document on a Network Printer.
+
+    Returns ``True`` when a job was enqueued, ``False`` when there is no
+    printer to send to (the call is intentionally a no-op in that case so a
+    missing-printer configuration never blocks the caller's workflow).
+    Printing happens via ``frappe.utils.print_format.print_by_server`` in a
+    short-queue worker so the request returns immediately.
+    """
+    target = printer or get_a4_printer()
+    if not target:
+        return False
+
+    fmt = print_format or _doctype_default_print_format(doctype)
+
+    frappe.enqueue(
+        "frappe.utils.print_format.print_by_server",
+        queue="short",
+        doctype=doctype,
+        name=name,
+        printer_setting=target,
+        print_format=fmt,
+    )
+    return True

--- a/isnack/utils/test_printing.py
+++ b/isnack/utils/test_printing.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026, Busuttil Technologies Limited and contributors
+# For license information, please see license.txt
+
+import unittest
+from unittest.mock import patch
+
+from isnack.utils import printing
+
+
+class TestEnqueueDocPrint(unittest.TestCase):
+    """`enqueue_doc_print` resolves the printer + Print Format and enqueues a job."""
+
+    @patch("isnack.utils.printing.frappe.enqueue")
+    @patch("isnack.utils.printing.frappe.db.get_value",
+           return_value="Isnack Packing Slip")
+    @patch("isnack.utils.printing.get_a4_printer", return_value="Main A4")
+    def test_resolves_defaults_and_enqueues(
+        self, _printer, _get_value, mock_enqueue
+    ):
+        result = printing.enqueue_doc_print("Packing Slip", "PS-001")
+
+        self.assertTrue(result)
+        mock_enqueue.assert_called_once_with(
+            "frappe.utils.print_format.print_by_server",
+            queue="short",
+            doctype="Packing Slip",
+            name="PS-001",
+            printer_setting="Main A4",
+            print_format="Isnack Packing Slip",
+        )
+
+    @patch("isnack.utils.printing.frappe.enqueue")
+    @patch("isnack.utils.printing.get_a4_printer", return_value=None)
+    def test_no_printer_is_a_noop(self, _printer, mock_enqueue):
+        # When no A4 printer is configured the helper must not enqueue
+        # anything, so a missing-printer setup never blocks Delivery Note
+        # submission.
+        self.assertFalse(printing.enqueue_doc_print("Packing Slip", "PS-001"))
+        mock_enqueue.assert_not_called()
+
+    @patch("isnack.utils.printing.frappe.enqueue")
+    @patch("isnack.utils.printing.frappe.db.get_value", return_value=None)
+    @patch("isnack.utils.printing.get_a4_printer", return_value="Main A4")
+    def test_falls_back_to_standard_print_format(
+        self, _printer, _get_value, mock_enqueue
+    ):
+        printing.enqueue_doc_print("Packing Slip", "PS-001")
+
+        kwargs = mock_enqueue.call_args.kwargs
+        self.assertEqual(kwargs["print_format"], "Standard")
+
+    @patch("isnack.utils.printing.frappe.enqueue")
+    @patch("isnack.utils.printing.get_a4_printer", return_value="Main A4")
+    def test_explicit_overrides_win(self, _printer, mock_enqueue):
+        printing.enqueue_doc_print(
+            "Packing Slip", "PS-001",
+            printer="Override Printer", print_format="Custom PF",
+        )
+
+        kwargs = mock_enqueue.call_args.kwargs
+        self.assertEqual(kwargs["printer_setting"], "Override Printer")
+        self.assertEqual(kwargs["print_format"], "Custom PF")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Auto-created Packing Slips were being submitted but not printed. After ps.submit() the Delivery Note hook now enqueues a print_by_server job targeting the configured A4 Network Printer, using the Packing Slip's default Print Format. Enqueue failures are logged and swallowed so a printer outage never blocks Delivery Note submission; missing-printer configuration is a silent no-op for the same reason.