### PR TITLE
Add Print Work Orders button to Production Plan form

### DIFF
--- a/isnack/public/js/production_plan.js
+++ b/isnack/public/js/production_plan.js
@@ -37,6 +37,9 @@ frappe.ui.form.on("Production Plan", {
       frm.add_custom_button(__("Print Pallet Labels"), () =>
         isnack_show_pallet_label_dialog(frm)
       );
+      frm.add_custom_button(__("Print Work Orders"), () =>
+        isnack_print_work_orders(frm)
+      );
     }
   },
 
@@ -126,6 +129,34 @@ function isnack_load_production_plan_defaults(frm) {
       const d = (r && r.message) || {};
       frm.__isnack_assembly_item_group = d.assembly_item_group || null;
       frm.__isnack_default_fg_warehouse = d.default_finished_goods_warehouse || null;
+    },
+  });
+}
+
+// Print all Work Orders linked to the Production Plan as a single PDF using
+// the "Work Order Detailed" print format.
+function isnack_print_work_orders(frm) {
+  frappe.call({
+    method: "frappe.client.get_list",
+    args: {
+      doctype: "Work Order",
+      fields: ["name"],
+      filters: { production_plan: frm.doc.name },
+      order_by: "creation asc",
+      limit_page_length: 0,
+    },
+    callback(r) {
+      const names = (r.message || []).map((d) => d.name);
+      if (!names.length) {
+        frappe.msgprint(__("No Work Orders found for this Production Plan."));
+        return;
+      }
+      const url =
+        "/api/method/frappe.utils.print_format.download_multi_pdf" +
+        "?doctype=" + encodeURIComponent("Work Order") +
+        "&name=" + encodeURIComponent(JSON.stringify(names)) +
+        "&format=" + encodeURIComponent("Work Order Detailed");
+      window.open(url, "_blank");
     },
   });
 }


### PR DESCRIPTION
## Summary
Added a new "Print Work Orders" custom button to the Production Plan form that allows users to print all linked Work Orders as a single PDF document.

## Key Changes
- Added a new custom button "Print Work Orders" to the Production Plan form UI
- Implemented `isnack_print_work_orders()` function that:
  - Fetches all Work Orders linked to the current Production Plan via `frappe.client.get_list`
  - Retrieves Work Orders in creation order with no page limit
  - Displays a user-friendly message if no Work Orders are found
  - Generates a download URL using Frappe's `download_multi_pdf` API endpoint
  - Opens the PDF in a new browser tab using the "Work Order Detailed" print format

## Implementation Details
- The function uses Frappe's standard API methods for querying and printing documents
- Work Orders are sorted by creation date in ascending order
- The print format is hardcoded to "Work Order Detailed" for consistency
- Error handling includes a check for empty Work Order lists with user notification

https://claude.ai/code/session_015nJ4jnwz4ay8m5Nh2jNvfu