### PR TITLE
Re-quantise SI item Currency fields after validate

### DIFF
--- a/isnack/hooks.py
+++ b/isnack/hooks.py
@@ -170,6 +170,9 @@ doc_events = {
         "validate": "isnack.api.delivery_note_pallets.calculate_delivery_note_pallets",
         "before_submit": "isnack.api.delivery_note_packing_slips.auto_create_packing_slips_before_submit",
     },
+    "Sales Invoice": {
+        "validate": "isnack.overrides.sales_invoice.quantise_item_currency_fields",
+    },
 }
 
 # doc_events = {

--- a/isnack/overrides/sales_invoice.py
+++ b/isnack/overrides/sales_invoice.py
@@ -1,0 +1,26 @@
+from frappe.utils import flt
+
+
+# Currency fields on Sales Invoice Item that ERPNext's calculate_item_values
+# (erpnext/controllers/taxes_and_totals.py) writes via raw subtraction without
+# flt(..., precision) — e.g. `item.discount_amount = price_list_rate - rate`.
+# On submitted-doc updates, Frappe's _validate_update_after_submit compares
+# old vs new with raw `!=`, so the sub-cent FP drift from those subtractions
+# trips "Not allowed to change ... after submission" even when the value is
+# unchanged at currency precision. Re-quantising after ERPNext's validate
+# snaps each field back to its precision so the diff check passes.
+_ITEM_FIELDS_TO_QUANTISE = (
+    "discount_amount",
+    "base_discount_amount",
+    "rate",
+    "base_rate",
+)
+
+
+def quantise_item_currency_fields(doc, method=None):
+    for item in doc.get("items") or []:
+        for fieldname in _ITEM_FIELDS_TO_QUANTISE:
+            value = item.get(fieldname)
+            if value is None:
+                continue
+            item.set(fieldname, flt(value, item.precision(fieldname)))


### PR DESCRIPTION
ERPNext's calculate_item_values writes
'item.discount_amount = price_list_rate - rate' (and rate variants in the margin branch) without flt(..., precision). The resulting sub-cent FP drift (e.g. 2.45 - 2.38 = 0.07000000000000028) is then compared against the DB value with a raw '!=' by Frappe's
_validate_update_after_submit, so editing an allow_on_submit field like custom_customs_document_no on a submitted Sales Invoice trips 'Not allowed to change Discount Amount after submission'.

Hooking on doc_events Sales Invoice validate runs after ERPNext's controller validate, so re-quantising discount_amount, base_discount_amount, rate and base_rate snaps the recomputed values back to currency precision and matches what was stored. flt is idempotent on clean values so the hook is a no-op for unaffected rows.