### PR TITLE
Make Operator Hub stock movements idempotent and concurrency-safe

### DIFF
--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -566,6 +566,113 @@ ROLES_OPERATOR = ["Factory Operator", "Operator", "Production Manager"]
 # Tolerance for floating point quantity comparisons
 QTY_EPSILON = 0.0001
 
+
+# ============================================================
+# Work Order locking + Stock Entry source-of-truth helpers
+# ------------------------------------------------------------
+# Operator Hub can fire the same stock movement more than once (Start retried,
+# button double-clicked, Close Production re-submitted). The cached
+# Work Order.material_transferred_for_manufacturing value is not a safe basis
+# for the "should I create another transfer?" decision because two concurrent
+# requests can both read the same stale value before either commits. We instead
+# (a) take a row lock on the Work Order for the duration of the transaction and
+# (b) sum the *submitted* Stock Entries as the source of truth.
+# ============================================================
+
+def _lock_work_order_for_update(work_order: str) -> None:
+    """Row-lock a single Work Order until the current transaction commits.
+
+    A concurrent request touching the same Work Order blocks here until we
+    commit, so it then reads our committed Stock Entries rather than the stale
+    pre-transfer state. This is what makes the MTFM/Manufacture decisions
+    concurrency-safe rather than merely idempotent on retry.
+    """
+    frappe.db.sql(
+        "select name from `tabWork Order` where name = %s for update",
+        (work_order,),
+    )
+
+
+def _lock_work_orders_for_update(work_orders: list[str]) -> None:
+    """Row-lock several Work Orders, always in deterministic (sorted) order.
+
+    Acquiring multiple row locks in a consistent order across all callers
+    prevents lock-ordering deadlocks when two Close Production requests overlap
+    on an intersecting set of Work Orders.
+    """
+    if not work_orders:
+        return
+    ordered = sorted(set(work_orders))
+    placeholders = ", ".join(["%s"] * len(ordered))
+    frappe.db.sql(
+        f"""
+        select name
+        from `tabWork Order`
+        where name in ({placeholders})
+        order by name
+        for update
+        """,
+        tuple(ordered),
+    )
+
+
+def _submitted_mtfm_qty(work_order: str) -> float:
+    """Sum of fg_completed_qty across submitted Material Transfer for Manufacture
+    Stock Entries for this Work Order — the authoritative "already transferred"
+    figure, independent of the cached Work Order field."""
+    return flt(frappe.db.sql("""
+        select coalesce(sum(fg_completed_qty), 0)
+        from `tabStock Entry`
+        where docstatus = 1
+          and purpose = 'Material Transfer for Manufacture'
+          and work_order = %s
+    """, (work_order,))[0][0])
+
+
+def _submitted_manufacture_qty(work_order: str) -> float:
+    """Sum of fg_completed_qty across submitted Manufacture Stock Entries for
+    this Work Order. Used to make Close Production idempotent so a retry does not
+    book a second Manufacture entry for a Work Order that is already produced."""
+    return flt(frappe.db.sql("""
+        select coalesce(sum(fg_completed_qty), 0)
+        from `tabStock Entry`
+        where docstatus = 1
+          and purpose = 'Manufacture'
+          and work_order = %s
+    """, (work_order,))[0][0])
+
+
+def _submitted_mtfm_item_qty_by_key(work_order: str) -> dict[tuple, float]:
+    """Per-(item, batch, uom) quantity already moved by submitted Material
+    Transfer for Manufacture entries for this Work Order.
+
+    Keyed by (item_code, batch_no, uom) with blank-string defaults so it can be
+    diffed against the staged rows when computing what still needs to move. Only
+    true warehouse-to-warehouse rows are counted (both s_warehouse and
+    t_warehouse set), matching how this flow builds MTFM rows.
+    """
+    rows = frappe.db.sql("""
+        select
+            sed.item_code,
+            coalesce(sed.batch_no, '') as batch_no,
+            coalesce(sed.uom, '') as uom,
+            coalesce(sum(sed.qty), 0) as qty
+        from `tabStock Entry` se
+        join `tabStock Entry Detail` sed on sed.parent = se.name
+        where se.docstatus = 1
+          and se.purpose = 'Material Transfer for Manufacture'
+          and se.work_order = %s
+          and sed.s_warehouse is not null
+          and sed.t_warehouse is not null
+        group by sed.item_code, coalesce(sed.batch_no, ''), coalesce(sed.uom, '')
+    """, (work_order,), as_dict=True)
+
+    return {
+        (r.item_code, r.batch_no or "", r.uom or ""): flt(r.qty)
+        for r in rows
+    }
+
+
 def _is_fg(item_code: str) -> bool:
     """Treat sales items as FG by policy (adjust to Item Group if you prefer)."""
     return bool(frappe.db.get_value("Item", item_code, "is_sales_item"))
@@ -1227,26 +1334,33 @@ def set_work_order_state(
         if not wo.actual_start_date:
             updates["actual_start_date"] = now
         
-        # NEW: Transfer staged materials to WIP
+        # Transfer staged materials to WIP. This MUST succeed before the Work
+        # Order is advanced to In Process — a Start that silently proceeds on a
+        # failed transfer leaves the WO running with broken stock movement.
+        # transfer_staged_to_wip is idempotent (it skips the MTFM when the WO is
+        # already fully transferred and only sweeps pending surplus), so a Start
+        # while already In Process will not create a duplicate MTFM.
         try:
             transfer_result = transfer_staged_to_wip(work_order)
-            if transfer_result.get("stock_entry"):
-                frappe.msgprint(_("Materials transferred from Staging to WIP: {0}").format(
-                    transfer_result["stock_entry"]
-                ))
-            surplus_transfers = transfer_result.get("surplus_transfers") or []
-            if surplus_transfers:
-                frappe.msgprint(_("Surplus transferred from Staging to WIP: {0}").format(
-                    ", ".join(surplus_transfers)
-                ))
         except Exception as e:
-            # Log the error but don't block the Start action
             frappe.log_error(
                 title="Transfer Staged To WIP Error",
                 message=f"Failed to transfer staged materials for {work_order}: {str(e)}",
             )
-            frappe.msgprint(_("Warning: Could not transfer staged materials. Error: {0}").format(str(e)), 
-                          indicator="orange")
+            frappe.throw(
+                _("Could not start Work Order because staged materials could not be "
+                  "transferred to WIP: {0}").format(str(e))
+            )
+
+        if transfer_result.get("stock_entry"):
+            frappe.msgprint(_("Materials transferred from Staging to WIP: {0}").format(
+                transfer_result["stock_entry"]
+            ))
+        surplus_transfers = transfer_result.get("surplus_transfers") or []
+        if surplus_transfers:
+            frappe.msgprint(_("Surplus transferred from Staging to WIP: {0}").format(
+                ", ".join(surplus_transfers)
+            ))
     elif action_lc == "pause":
         updates["status"] = "Stopped"
     elif action_lc == "stop":
@@ -1287,105 +1401,138 @@ def transfer_staged_to_wip(work_order: str, employee: Optional[str] = None):
     Important: This function preserves individual Stock Entry Detail rows from staging
     (no aggregation) to maintain serial_and_batch_bundle integrity. Each bundle
     represents a specific batch allocation that must be transferred as-is to WIP.
+
+    Idempotency & concurrency: the Work Order row is locked for the duration of
+    the transaction and submitted MTFM Stock Entries are the source of truth.
+    A second Start/retry/double-click cannot create a duplicate (or a zero-qty)
+    Material Transfer for Manufacture, and any rows already moved by a prior MTFM
+    are netted out so they are never transferred twice. Surplus is always swept
+    separately via plain Material Transfer, even when the normal MTFM is skipped.
     """
     _require_roles(ROLES_OPERATOR)
-    
+
+    # Serialize concurrent Start requests for this WO and ensure we read the
+    # committed transfer history rather than a stale cached counter.
+    _lock_work_order_for_update(work_order)
+
     wo = frappe.get_doc("Work Order", work_order)
     staging_wh = _default_line_staging(work_order)
     wip_wh = _default_line_wip(work_order)
-    
+
     if not staging_wh:
         frappe.throw(_("No Staging warehouse configured for this Work Order"))
     if not wip_wh:
         frappe.throw(_("No WIP warehouse configured for this Work Order"))
-    
-    # Get materials currently in staging for this WO
-    # Look for recent "Material Transfer" stock entries to this staging warehouse
-    # Note: work_order parameter is validated by frappe.get_doc() above, ensuring it's a valid Work Order name
-    # Using a more precise pattern match to avoid matching partial work order names
-    #
-    # IMPORTANT: Preserve each bundle as separate row (no aggregation) to maintain batch allocation integrity
-    #   - Fetch batch_no from staging transfer
-    #   - Let ERPNext create NEW serial_and_batch_bundle records (don't reuse existing ones)
-    #   - Each Stock Entry needs its own unique bundle, even if referencing the same batch
-    #   - ORDER BY preserves chronological order and row sequence from staging transfers
-    wo_escaped = frappe.db.escape(work_order)
-    items_in_staging = frappe.db.sql("""
-        SELECT 
-            sed.item_code,
-            sed.batch_no,
-            sed.uom,
-            sed.qty
-        FROM `tabStock Entry` se
-        JOIN `tabStock Entry Detail` sed ON sed.parent = se.name
-        WHERE se.docstatus = 1
-            AND se.purpose = 'Material Transfer'
-            AND sed.t_warehouse = %(staging_wh)s
-            AND (se.remarks LIKE %(wo_pattern1)s OR se.remarks LIKE %(wo_pattern2)s)
-            AND sed.qty > 0
-        ORDER BY se.posting_date, se.posting_time, sed.idx
-    """, {
-        'staging_wh': staging_wh,
-        'wo_pattern1': f'%WO: {work_order}|%',
-        'wo_pattern2': f'%WO: {work_order}'
-    }, as_dict=True)
-    
+
+    # Authoritative "already transferred" figure from submitted MTFM entries —
+    # NOT the cached wo.material_transferred_for_manufacturing, which two
+    # concurrent requests could both read pre-commit.
+    already_transferred = _submitted_mtfm_qty(work_order)
+    remaining_fg_qty = flt(wo.qty) - already_transferred
+
     se_name = None
-    if items_in_staging:
-        # Create Material Transfer for Manufacture
-        se = frappe.new_doc("Stock Entry")
-        se.company = wo.company
-        se.purpose = "Material Transfer for Manufacture"
-        se.stock_entry_type = "Material Transfer for Manufacture"
-        se.work_order = work_order
-        se.from_warehouse = staging_wh
-        se.to_warehouse = wip_wh
-        se.from_bom = 1
-        se.bom_no = wo.bom_no
-        se.use_multi_level_bom = wo.use_multi_level_bom
+    # Hard skip: when the Work Order is already fully transferred we must not
+    # create another MTFM at all (not even a zero-qty one). Surplus is still
+    # swept below.
+    if remaining_fg_qty > QTY_EPSILON:
+        # Read normal staged rows for this WO. Surplus source entries are
+        # excluded here (custom_is_surplus = 0); surplus moves via its own
+        # plain Material Transfer sweep.
+        #
+        # IMPORTANT: Preserve each row separately (no aggregation) to maintain
+        # batch allocation integrity. We fetch batch_no and let ERPNext create
+        # NEW serial_and_batch_bundle records — existing bundles belong to the
+        # staging transfer and must not be reused. ORDER BY preserves the
+        # chronological row sequence from staging transfers.
+        staged_rows = frappe.db.sql("""
+            SELECT
+                sed.item_code,
+                COALESCE(sed.batch_no, '') AS batch_no,
+                sed.uom,
+                sed.qty
+            FROM `tabStock Entry` se
+            JOIN `tabStock Entry Detail` sed ON sed.parent = se.name
+            WHERE se.docstatus = 1
+                AND se.purpose = 'Material Transfer'
+                AND COALESCE(se.custom_is_surplus, 0) = 0
+                AND sed.t_warehouse = %(staging_wh)s
+                AND (se.remarks LIKE %(wo_pattern1)s OR se.remarks LIKE %(wo_pattern2)s)
+                AND sed.qty > 0
+            ORDER BY se.posting_date, se.posting_time, sed.idx
+        """, {
+            'staging_wh': staging_wh,
+            'wo_pattern1': f'%WO: {work_order}|%',
+            'wo_pattern2': f'%WO: {work_order}'
+        }, as_dict=True)
 
-        # Set fg_completed_qty for ERPNext to update material_transferred_for_manufacturing
-        remaining_qty = flt(wo.qty) - flt(wo.material_transferred_for_manufacturing)
-        if remaining_qty <= 0:
-            frappe.msgprint(_("Warning: Material already transferred for full quantity. Proceeding with transfer."),
-                           indicator="orange")
-            se.fg_completed_qty = 0
-        else:
-            se.fg_completed_qty = remaining_qty
+        # Net out what submitted MTFM entries have already moved, per
+        # (item, batch, uom), preserving row-level batch identity.
+        already_moved = _submitted_mtfm_item_qty_by_key(work_order)
+        items_to_transfer = []
+        for row in staged_rows:
+            key = (row.item_code, row.batch_no or "", row.uom or "")
+            prior = flt(already_moved.get(key, 0))
 
-        if employee:
-            se.custom_operator = employee  # If you have this custom field
+            if prior >= flt(row.qty) - QTY_EPSILON:
+                # This whole staged row was already moved by a prior MTFM.
+                already_moved[key] = prior - flt(row.qty)
+                continue
 
-        # Add items from staging
-        for item in items_in_staging:
-            item_dict = {
-                "item_code": item.item_code,
-                "qty": item.qty,
-                "uom": item.uom,
-                "s_warehouse": staging_wh,
-                "t_warehouse": wip_wh,
-            }
+            qty_to_move = flt(row.qty) - max(prior, 0)
+            already_moved[key] = 0
 
-            # Handle batch tracking: Use batch_no and let ERPNext create new bundles
-            # Don't reuse serial_and_batch_bundle as it's already linked to the staging transfer
-            # Each Stock Entry needs its own unique bundle, even if referencing the same batch
-            if item.batch_no:
-                # Use batch_no and let ERPNext create a new bundle
-                item_dict["batch_no"] = item.batch_no
-                # use_serial_batch_fields=1 tells ERPNext to create a new bundle from batch_no
-                item_dict["use_serial_batch_fields"] = 1
-            # else: No batch tracking - ERPNext will handle as a regular item without batch/serial
+            if qty_to_move > QTY_EPSILON:
+                items_to_transfer.append({
+                    "item_code": row.item_code,
+                    "batch_no": row.batch_no or None,
+                    "uom": row.uom,
+                    "qty": qty_to_move,
+                })
 
-            se.append("items", item_dict)
+        if items_to_transfer:
+            # Create Material Transfer for Manufacture
+            se = frappe.new_doc("Stock Entry")
+            se.company = wo.company
+            se.purpose = "Material Transfer for Manufacture"
+            se.stock_entry_type = "Material Transfer for Manufacture"
+            se.work_order = work_order
+            se.from_warehouse = staging_wh
+            se.to_warehouse = wip_wh
+            se.from_bom = 1
+            se.bom_no = wo.bom_no
+            se.use_multi_level_bom = wo.use_multi_level_bom
+            # Cap at the remaining FG qty so the submitted MTFM total can never
+            # exceed the planned Work Order quantity.
+            se.fg_completed_qty = remaining_fg_qty
 
-        se.flags.ignore_permissions = True
-        se.insert()
-        se.submit()
-        se_name = se.name
+            if employee:
+                se.custom_operator = employee  # If you have this custom field
+
+            for item in items_to_transfer:
+                item_dict = {
+                    "item_code": item["item_code"],
+                    "qty": item["qty"],
+                    "uom": item["uom"],
+                    "s_warehouse": staging_wh,
+                    "t_warehouse": wip_wh,
+                }
+                # Use batch_no + use_serial_batch_fields so ERPNext v15 creates a
+                # NEW transaction-specific bundle; never reuse the staging bundle.
+                if item["batch_no"]:
+                    item_dict["batch_no"] = item["batch_no"]
+                    item_dict["use_serial_batch_fields"] = 1
+
+                se.append("items", item_dict)
+
+            se.flags.ignore_permissions = True
+            se.insert()
+            se.submit()
+            se_name = se.name
 
     # Sweep any eligible surplus (from a Consolidated Pick Cart) into WIP too, so
-    # operators can consume it during production close. This runs even when there
-    # are no normal staged materials left for this WO.
+    # operators can consume it during production close. This runs even when the
+    # normal MTFM was skipped (WO already fully transferred) so late surplus can
+    # still move from Staging to WIP.
     surplus_transfers = _sweep_surplus_to_wip(work_order, staging_wh, wip_wh, wo, employee)
 
     if not se_name and not surplus_transfers:
@@ -3094,6 +3241,34 @@ def _close_single_wo(wo_data: dict, split: dict, batch_no: str) -> None:
     wo_name = wo_data["name"]
     try:
         wo = frappe.get_doc("Work Order", wo_name)
+
+        # Guard against the duplicate-MTFM corruption that motivated this flow:
+        # if submitted Material Transfer for Manufacture quantity already exceeds
+        # the planned qty, a duplicate transfer exists and must be fixed manually
+        # before production can be closed (we do not auto-repair vouchers).
+        transferred_qty = _submitted_mtfm_qty(wo_name)
+        if transferred_qty > flt(wo.qty) + QTY_EPSILON:
+            frappe.throw(
+                _("Work Order {0} has excess Material Transfer for Manufacture quantity "
+                  "({1} > {2}). Please fix the duplicate transfer before closing production.")
+                .format(wo_name, transferred_qty, wo.qty)
+            )
+
+        # Idempotency: if a submitted Manufacture entry already covers this Work
+        # Order (double-click / retry), do not book a second one. Just ensure the
+        # WO is marked Completed and return.
+        if _submitted_manufacture_qty(wo_name) >= flt(wo.qty) - QTY_EPSILON:
+            frappe.db.set_value(
+                "Work Order",
+                wo_name,
+                {
+                    "status": "Completed",
+                    "actual_end_date": wo.actual_end_date or frappe.utils.now_datetime(),
+                    "custom_production_ended": 0,
+                },
+            )
+            return
+
         fg_wh = (
             wo.fg_warehouse
             or _default_line_target(wo_name)
@@ -3102,6 +3277,14 @@ def _close_single_wo(wo_data: dict, split: dict, batch_no: str) -> None:
         uom = frappe.db.get_value("Item", wo.production_item, "stock_uom") or "Nos"
         wip_wh = wo.wip_warehouse or _default_line_wip(wo_name)
         has_batch = bool(frappe.db.get_value("Item", wo.production_item, "has_batch_no"))
+
+        # Late surplus sweep: surplus may have been added after Start but before
+        # Close Production. Move it Staging -> WIP now (plain Material Transfer,
+        # never Material Transfer for Manufacture) so it is available in WIP for
+        # over-consumption during this close.
+        staging_wh = _default_line_staging(wo_name)
+        if staging_wh and wip_wh:
+            _sweep_surplus_to_wip(wo_name, staging_wh, wip_wh, wo)
 
         scrap_wh = None
         if split["reject"] > 0:
@@ -3438,19 +3621,42 @@ def close_production(groups: str = None, lines: str = None,
     # Single Factory-Settings validation across everything being closed.
     _validate_close_production(line_list, all_ended_wos)
 
+    # Lock every Work Order we are about to close, in deterministic order, so a
+    # concurrent Close Production (double-click / retry) blocks here and then
+    # sees the committed Completed status instead of re-booking Manufacture.
+    _lock_work_orders_for_update([wo["name"] for wo in all_ended_wos])
+
     completed_wos = []
+    skipped_wos = []
     for entry in prepared:
         splits = _calculate_proportional_split(
             entry["ended_wos"], entry["good_qty"], entry["reject_qty"], entry["packaging_items"],
         )
         for wo_data in entry["ended_wos"]:
+            # Re-read status under the lock: another request may have completed
+            # this Work Order while we were waiting to acquire the lock.
+            current_status = frappe.db.get_value("Work Order", wo_data["name"], "status")
+            if current_status == "Completed":
+                skipped_wos.append(wo_data["name"])
+                continue
             _close_single_wo(wo_data, splits[wo_data["name"]], entry["batch_no"])
             completed_wos.append(wo_data["name"])
+
+    if not completed_wos:
+        # Everything was already closed by a concurrent/earlier request — treat
+        # as a successful no-op rather than throwing.
+        return {
+            "success": True,
+            "message": "Production already closed for the selected work order(s)",
+            "completed_wos": [],
+            "skipped_wos": skipped_wos,
+        }
 
     return {
         "success": True,
         "message": f"Successfully closed production for {len(completed_wos)} work order(s)",
         "completed_wos": completed_wos,
+        "skipped_wos": skipped_wos,
     }
 
 @frappe.whitelist()

--- a/isnack/api/test_mes_ops_idempotency.py
+++ b/isnack/api/test_mes_ops_idempotency.py
@@ -1,0 +1,300 @@
+# Copyright (c) 2026, Busuttil Technologies Limited and contributors
+# For license information, please see license.txt
+
+"""Unit tests for Operator Hub stock-movement idempotency and concurrency safety.
+
+These cover the duplicate / over-transfer corruption that motivated the
+locking + submitted-Stock-Entry-as-source-of-truth rework in
+``transfer_staged_to_wip`` / ``close_production`` / ``_close_single_wo``.
+
+The functions under test call many module-level helpers; we patch those so the
+tests assert behaviour (was a Material Transfer for Manufacture created? with
+what fg_completed_qty? was surplus still swept?) without needing a live site.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import frappe
+
+import isnack.api.mes_ops as mes_ops
+from isnack.api.mes_ops import transfer_staged_to_wip, set_work_order_state, _close_single_wo
+
+
+class FakeStockEntry:
+    """Minimal stand-in for a Stock Entry doc that records appended rows and
+    whether it was inserted/submitted, while accepting arbitrary attributes."""
+
+    def __init__(self):
+        self.items = []
+        self.flags = MagicMock()
+        self.name = "MAT-STE-NEW"
+        self.inserted = False
+        self.submitted = False
+
+    def append(self, table, row):
+        self.items.append(row)
+
+    def insert(self):
+        self.inserted = True
+
+    def submit(self):
+        self.submitted = True
+
+
+def _wo(qty=332.0, company="Test Co", bom_no="BOM-001"):
+    wo = MagicMock()
+    wo.qty = qty
+    wo.company = company
+    wo.bom_no = bom_no
+    wo.use_multi_level_bom = 0
+    wo.actual_end_date = None
+    wo.wip_warehouse = "WIP-A"
+    wo.fg_warehouse = "FG-A"
+    wo.production_item = "FG-ITEM"
+    return wo
+
+
+class TestTransferStagedToWipIdempotency(unittest.TestCase):
+    """Scenarios 1, 2, 3, 7."""
+
+    def _run(self, *, submitted_mtfm, staged_rows, already_moved, surplus=None):
+        """Invoke transfer_staged_to_wip with all collaborators patched.
+
+        Returns (result, new_doc_mock) so tests can assert whether an MTFM Stock
+        Entry was created and how it was configured.
+        """
+        surplus = surplus or []
+        new_doc = MagicMock(side_effect=lambda dt: FakeStockEntry())
+        with patch.object(mes_ops, "_require_roles"), \
+             patch.object(mes_ops, "_lock_work_order_for_update") as lock, \
+             patch.object(mes_ops, "_default_line_staging", return_value="Stage-A"), \
+             patch.object(mes_ops, "_default_line_wip", return_value="WIP-A"), \
+             patch.object(mes_ops, "_submitted_mtfm_qty", return_value=submitted_mtfm), \
+             patch.object(mes_ops, "_submitted_mtfm_item_qty_by_key", return_value=dict(already_moved)), \
+             patch.object(mes_ops, "_sweep_surplus_to_wip", return_value=surplus) as sweep, \
+             patch.object(mes_ops.frappe, "get_doc", return_value=_wo()), \
+             patch.object(mes_ops.frappe.db, "sql", return_value=staged_rows), \
+             patch.object(mes_ops.frappe, "new_doc", new_doc):
+            result = transfer_staged_to_wip("MFG-WO-0001")
+        return result, new_doc, lock, sweep
+
+    def test_first_start_creates_one_mtfm(self):
+        """Scenario 1a: fresh WO -> exactly one MTFM, WO locked first."""
+        staged = [frappe._dict(item_code="RM1", batch_no="B1", uom="Kg", qty=100.0)]
+        result, new_doc, lock, sweep = self._run(
+            submitted_mtfm=0.0, staged_rows=staged, already_moved={},
+        )
+        # WO row was locked before anything else.
+        lock.assert_called_once_with("MFG-WO-0001")
+        # Exactly one MTFM Stock Entry created.
+        new_doc.assert_called_once_with("Stock Entry")
+        self.assertEqual(result["stock_entry"], "MAT-STE-NEW")
+
+    def test_first_start_fg_completed_qty_and_rows(self):
+        """Scenario 1a detail: fg_completed_qty == full qty, all rows moved."""
+        staged = [
+            frappe._dict(item_code="RM1", batch_no="B1", uom="Kg", qty=100.0),
+            frappe._dict(item_code="RM2", batch_no="", uom="Nos", qty=5.0),
+        ]
+        created = {}
+        def make(dt):
+            se = FakeStockEntry()
+            created["se"] = se
+            return se
+        with patch.object(mes_ops, "_require_roles"), \
+             patch.object(mes_ops, "_lock_work_order_for_update"), \
+             patch.object(mes_ops, "_default_line_staging", return_value="Stage-A"), \
+             patch.object(mes_ops, "_default_line_wip", return_value="WIP-A"), \
+             patch.object(mes_ops, "_submitted_mtfm_qty", return_value=0.0), \
+             patch.object(mes_ops, "_submitted_mtfm_item_qty_by_key", return_value={}), \
+             patch.object(mes_ops, "_sweep_surplus_to_wip", return_value=[]), \
+             patch.object(mes_ops.frappe, "get_doc", return_value=_wo(qty=332.0)), \
+             patch.object(mes_ops.frappe.db, "sql", return_value=staged), \
+             patch.object(mes_ops.frappe, "new_doc", side_effect=make):
+            transfer_staged_to_wip("MFG-WO-0001")
+
+        se = created["se"]
+        self.assertEqual(se.purpose, "Material Transfer for Manufacture")
+        self.assertEqual(se.stock_entry_type, "Material Transfer for Manufacture")
+        self.assertEqual(se.fg_completed_qty, 332.0)
+        self.assertEqual(len(se.items), 2)
+        # Batch row carries batch_no + use_serial_batch_fields; non-batch row does not.
+        self.assertEqual(se.items[0]["batch_no"], "B1")
+        self.assertEqual(se.items[0]["use_serial_batch_fields"], 1)
+        self.assertNotIn("batch_no", se.items[1])
+        self.assertTrue(se.submitted)
+
+    def test_second_start_creates_no_mtfm(self):
+        """Scenario 1b & 7: WO already fully transferred -> no MTFM at all,
+        not even a zero-qty one. Surplus sweep still runs."""
+        staged = [frappe._dict(item_code="RM1", batch_no="B1", uom="Kg", qty=100.0)]
+        result, new_doc, lock, sweep = self._run(
+            submitted_mtfm=332.0, staged_rows=staged,
+            already_moved={("RM1", "B1", "Kg"): 100.0},
+        )
+        new_doc.assert_not_called()           # no Stock Entry built
+        self.assertIsNone(result["stock_entry"])
+        sweep.assert_called_once()            # surplus still swept
+
+    def test_already_transferred_still_sweeps_surplus(self):
+        """Scenario 2: normal MTFM skipped, surplus moved via the sweep."""
+        result, new_doc, lock, sweep = self._run(
+            submitted_mtfm=332.0, staged_rows=[], already_moved={},
+            surplus=["MAT-STE-SURPLUS"],
+        )
+        new_doc.assert_not_called()
+        sweep.assert_called_once()
+        self.assertEqual(result["surplus_transfers"], ["MAT-STE-SURPLUS"])
+
+    def test_partial_transfer_moves_only_remainder(self):
+        """Scenario 3: prior MTFM covered part of qty and part of a staged row;
+        new MTFM is for the remaining FG qty and the net-remaining row qty."""
+        staged = [frappe._dict(item_code="RM1", batch_no="B1", uom="Kg", qty=100.0)]
+        created = {}
+        def make(dt):
+            se = FakeStockEntry()
+            created["se"] = se
+            return se
+        with patch.object(mes_ops, "_require_roles"), \
+             patch.object(mes_ops, "_lock_work_order_for_update"), \
+             patch.object(mes_ops, "_default_line_staging", return_value="Stage-A"), \
+             patch.object(mes_ops, "_default_line_wip", return_value="WIP-A"), \
+             patch.object(mes_ops, "_submitted_mtfm_qty", return_value=200.0), \
+             patch.object(mes_ops, "_submitted_mtfm_item_qty_by_key",
+                          return_value={("RM1", "B1", "Kg"): 60.0}), \
+             patch.object(mes_ops, "_sweep_surplus_to_wip", return_value=[]), \
+             patch.object(mes_ops.frappe, "get_doc", return_value=_wo(qty=332.0)), \
+             patch.object(mes_ops.frappe.db, "sql", return_value=staged), \
+             patch.object(mes_ops.frappe, "new_doc", side_effect=make):
+            transfer_staged_to_wip("MFG-WO-0001")
+
+        se = created["se"]
+        # Remaining FG qty = 332 - 200.
+        self.assertAlmostEqual(se.fg_completed_qty, 132.0)
+        # Net row qty = 100 - 60 already moved.
+        self.assertEqual(len(se.items), 1)
+        self.assertAlmostEqual(se.items[0]["qty"], 40.0)
+
+    def test_no_zero_qty_mtfm_when_rows_already_moved(self):
+        """Scenario 7 variant: remaining FG qty > 0 but every staged row was
+        already physically moved -> no MTFM created."""
+        staged = [frappe._dict(item_code="RM1", batch_no="B1", uom="Kg", qty=100.0)]
+        result, new_doc, lock, sweep = self._run(
+            submitted_mtfm=0.0, staged_rows=staged,
+            already_moved={("RM1", "B1", "Kg"): 100.0},
+        )
+        new_doc.assert_not_called()
+        self.assertIsNone(result["stock_entry"])
+
+
+class TestStartFailsHardOnTransferError(unittest.TestCase):
+    """Scenario 6."""
+
+    def test_start_does_not_advance_when_transfer_fails(self):
+        thrown = RuntimeError("transfer blew up")
+
+        def fake_throw(*args, **kwargs):
+            raise RuntimeError("frappe.throw")
+
+        with patch.object(mes_ops, "_require_roles"), \
+             patch.object(mes_ops, "_assert_not_ended"), \
+             patch.object(mes_ops, "_storekeeper_stage_status", return_value="Staged"), \
+             patch.object(mes_ops, "transfer_staged_to_wip", side_effect=thrown), \
+             patch.object(mes_ops.frappe, "get_doc", return_value=_wo()), \
+             patch.object(mes_ops.frappe, "log_error") as log_error, \
+             patch.object(mes_ops.frappe.utils, "now_datetime", return_value="2026-06-03 10:00:00"), \
+             patch.object(mes_ops.frappe.db, "set_value") as set_value, \
+             patch.object(mes_ops.frappe, "throw", side_effect=fake_throw):
+            with self.assertRaises(RuntimeError):
+                set_work_order_state("MFG-WO-0001", "Start")
+
+        # The failure was logged and the WO status was never written.
+        log_error.assert_called_once()
+        set_value.assert_not_called()
+
+
+class TestCloseSingleWoIdempotency(unittest.TestCase):
+    """Scenarios 4 and 5."""
+
+    def test_skips_manufacture_when_already_produced(self):
+        """Scenario 5: a submitted Manufacture entry already covers the WO ->
+        no second Manufacture is booked; WO is marked Completed."""
+        with patch.object(mes_ops.frappe, "get_doc", return_value=_wo(qty=332.0)), \
+             patch.object(mes_ops, "_submitted_mtfm_qty", return_value=332.0), \
+             patch.object(mes_ops, "_submitted_manufacture_qty", return_value=332.0), \
+             patch.object(mes_ops.frappe.utils, "now_datetime", return_value="2026-06-03 10:00:00"), \
+             patch.object(mes_ops.frappe, "new_doc") as new_doc, \
+             patch.object(mes_ops.frappe.db, "set_value") as set_value:
+            _close_single_wo({"name": "MFG-WO-0001"},
+                             {"good": 332.0, "reject": 0, "packaging": []}, "ABC-001")
+
+        new_doc.assert_not_called()  # no Manufacture Stock Entry created
+        # WO marked Completed.
+        status_calls = [c for c in set_value.call_args_list
+                        if c[0][0] == "Work Order" and isinstance(c[0][2], dict)
+                        and c[0][2].get("status") == "Completed"]
+        self.assertTrue(status_calls)
+
+    def test_excess_mtfm_blocks_close(self):
+        """Pre-check: submitted MTFM exceeding planned qty stops the close."""
+        def fake_throw(*args, **kwargs):
+            raise RuntimeError("excess")
+
+        with patch.object(mes_ops.frappe, "get_doc", return_value=_wo(qty=332.0)), \
+             patch.object(mes_ops, "_submitted_mtfm_qty", return_value=664.0), \
+             patch.object(mes_ops.frappe, "log_error"), \
+             patch.object(mes_ops.frappe, "new_doc") as new_doc, \
+             patch.object(mes_ops.frappe, "throw", side_effect=fake_throw):
+            with self.assertRaises(RuntimeError):
+                _close_single_wo({"name": "MFG-WO-0001"},
+                                 {"good": 332.0, "reject": 0, "packaging": []}, "ABC-001")
+        new_doc.assert_not_called()
+
+    def test_late_surplus_swept_before_manufacture(self):
+        """Scenario 4: surplus added after Start is swept (plain Material
+        Transfer) before the Manufacture entry is built."""
+        order = []
+
+        def fake_sweep(wo_name, staging, wip, wo, *a, **k):
+            order.append("sweep")
+            return ["MAT-STE-SURPLUS"]
+
+        def make(dt):
+            order.append("manufacture_se")
+            return FakeStockEntry()
+
+        def db_get_value(doctype, name, field, *a, **k):
+            if field == "stock_uom":
+                return "Nos"
+            if field == "has_batch_no":
+                return 0
+            return None
+
+        with patch.object(mes_ops.frappe, "get_doc", return_value=_wo(qty=10.0)), \
+             patch.object(mes_ops, "_submitted_mtfm_qty", return_value=10.0), \
+             patch.object(mes_ops, "_submitted_manufacture_qty", return_value=0.0), \
+             patch.object(mes_ops, "_default_line_target", return_value="FG-A"), \
+             patch.object(mes_ops, "_default_line_wip", return_value="WIP-A"), \
+             patch.object(mes_ops, "_default_line_staging", return_value="Stage-A"), \
+             patch.object(mes_ops, "_sweep_surplus_to_wip", side_effect=fake_sweep) as sweep, \
+             patch.object(mes_ops, "_get_consumed_materials_from_load", return_value={}), \
+             patch.object(mes_ops, "_get_bom_items_for_quantity", return_value=[]), \
+             patch.object(mes_ops, "_apply_pre_consumed_cost_to_finished_item"), \
+             patch.object(mes_ops.frappe.utils, "now_datetime", return_value="2026-06-03 10:00:00"), \
+             patch.object(mes_ops.frappe.db, "get_value", side_effect=db_get_value), \
+             patch.object(mes_ops.frappe.db, "get_single_value", return_value="FG-A"), \
+             patch.object(mes_ops.frappe.db, "set_value"), \
+             patch.object(mes_ops.frappe, "new_doc", side_effect=make):
+            _close_single_wo({"name": "MFG-WO-0001"},
+                             {"good": 10.0, "reject": 0, "packaging": []}, "ABC-001")
+
+        sweep.assert_called_once()
+        # Surplus sweep happens before the Manufacture Stock Entry is built.
+        self.assertEqual(order[0], "sweep")
+        self.assertIn("manufacture_se", order)
+        self.assertLess(order.index("sweep"), order.index("manufacture_se"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/isnack/isnack/page/operator_hub/operator_hub.js
+++ b/isnack/isnack/page/operator_hub/operator_hub.js
@@ -952,9 +952,21 @@ function init_operator_hub($root) {
 
   // ---------- Buttons ----------
   async function doStart() {
-    await rpc('isnack.api.mes_ops.set_work_order_state', { work_order: state.current_wo, action:'Start' });
-    flashStatus(`Started — ${state.current_wo}`, 'success');
-    await updateAfterAction();
+    // In-flight guard: the Start RPC now triggers Staging -> WIP transfer and
+    // fails hard if it cannot complete, so a repeated click while it is pending
+    // must not fire a second transfer. refreshButtonStates() restores the
+    // correct enabled/disabled state once the request settles.
+    if (state.__starting) return;
+    state.__starting = true;
+    $('#btn-start', $root).prop('disabled', true);
+    try {
+      await rpc('isnack.api.mes_ops.set_work_order_state', { work_order: state.current_wo, action:'Start' });
+      flashStatus(`Started — ${state.current_wo}`, 'success');
+      await updateAfterAction();
+    } finally {
+      state.__starting = false;
+      refreshButtonStates();
+    }
   }
 
   $('#btn-start',$root).on('click', () => {
@@ -2745,7 +2757,13 @@ function init_operator_hub($root) {
       fields,
       size: 'extra-large',
       primary_action_label:'Close Production',
-      primary_action: (v) => {
+      primary_action: async (v) => {
+        // In-flight guard: ignore repeat clicks while a close is already
+        // running. The button is disabled synchronously below before we await
+        // the RPC, so a second queued click lands here and bails out.
+        const $btn = d.get_primary_btn();
+        if ($btn.prop('disabled')) return;
+
         const batchPattern = /^[A-Za-z]{3}-\d{3}$/;
         const payload = [];
         const batchSeen = new Map(); // batch_no -> production_item
@@ -2807,17 +2825,22 @@ function init_operator_hub($root) {
           });
         }
 
+        // Disable synchronously (before any await) so a double-click cannot
+        // fire a second close_production. Re-enable only on error.
         setStatus('Closing production…');
-        rpc('isnack.api.mes_ops.close_production', {
-          groups: JSON.stringify(payload),
-          lines: JSON.stringify(state.current_lines),
-        }).then(() => {
+        $btn.prop('disabled', true).text(__('Closing…'));
+        try {
+          await rpc('isnack.api.mes_ops.close_production', {
+            groups: JSON.stringify(payload),
+            lines: JSON.stringify(state.current_lines),
+          });
           d.hide();
           flashStatus(`Production closed for ${endedWOs.length} work order(s)`, 'success');
-          load_queue();
-        }).catch(err => {
+          await load_queue();
+        } catch (err) {
           console.error('close_production failed', err);
-        });
+          $btn.prop('disabled', false).text(__('Close Production'));
+        }
       },
     });
 


### PR DESCRIPTION
Operator Hub could create duplicate/over-transfer Material Transfer for Manufacture (MTFM) Stock Entries when a Work Order was started, retried or double-clicked, tripping ERPNext's over-transfer validation and corrupting Serial and Batch Bundles (incident: MFG-WO-2026-00002).

Backend (isnack/api/mes_ops.py):
- Add _lock_work_order_for_update / _lock_work_orders_for_update row locks (deterministic ordering to avoid deadlocks).
- Add _submitted_mtfm_qty, _submitted_manufacture_qty and _submitted_mtfm_item_qty_by_key: submitted Stock Entries are now the source of truth, not the cached material_transferred_for_manufacturing.
- transfer_staged_to_wip: lock the WO, hard-skip MTFM creation when the WO is already fully transferred (never create a zero-qty MTFM), cap fg_completed_qty at the remaining FG qty, and net staged rows against what submitted MTFMs already moved (per item/batch/uom) so nothing is transferred twice. Surplus is still swept via plain Material Transfer even when the normal MTFM is skipped. Normal staged rows now exclude surplus source entries (custom_is_surplus = 0).
- set_work_order_state Start: fail hard (throw) if the Staging -> WIP transfer fails, so a WO never advances to In Process on broken stock movement.
- _close_single_wo: block close when submitted MTFM exceeds planned qty (manual fix required - no auto-repair); skip booking a second Manufacture when one already covers the WO; sweep late surplus (plain Material Transfer) before building the Manufacture entry.
- close_production: lock all ended WOs, re-read status under the lock, skip already-Completed WOs, and return a successful no-op when nothing remains to close.

Frontend (operator_hub.js):
- Close Production primary action is async with an in-flight guard and disables synchronously before awaiting the RPC (re-enables on error).
- Start handler guards against repeat clicks while the RPC is pending.

Tests:
- New test_mes_ops_idempotency.py covering start-twice, already- transferred-with-surplus, partial transfer, no zero-qty MTFM, late surplus sweep at close, close idempotency, excess-MTFM block, and hard-fail on transfer error.