### PR TITLE
Set Sales Invoice print 'modified' to Malta local time (CEST)

### DIFF
--- a/isnack/isnack/print_format/sales_invoice/sales_invoice.json
+++ b/isnack/isnack/print_format/sales_invoice/sales_invoice.json
@@ -16,7 +16,7 @@
  "margin_left": 15.0,
  "margin_right": 15.0,
  "margin_top": 15.0,
- "modified": "2026-06-07 07:40:20.566157",
+ "modified": "2026-06-07 09:53:15.459445",
  "modified_by": "Administrator",
  "module": "Isnack",
  "name": "Sales Invoice",


### PR DESCRIPTION
The previous timestamp was written in UTC, two hours behind Malta time, so Frappe treated the record as older and skipped the import. Use the current Malta (UTC+2) time so it re-imports.