### PR TITLE
Traceability report: rename output title and RM column group

### DIFF
--- a/isnack/isnack/report/customs_export_traceability_report/customs_export_traceability_report.py
+++ b/isnack/isnack/report/customs_export_traceability_report/customs_export_traceability_report.py
@@ -996,7 +996,7 @@ def get_export_excel(filters):
 	# A) Report header (written once)
 	# ---------------------------------------------------------------------------
 	_write_merged_row(
-		"Customs Export Traceability Report",
+		"Consumption Form / Fiche de Côsommation",
 		font=_bold_font(size=14),
 		align=ALIGN_CENTER,
 	)
@@ -1157,7 +1157,7 @@ def get_export_excel(filters):
 		ws.append([""] * TOTAL_COLS)
 		# "Raw Material" spans cols 1-4
 		rm_group_cell = ws.cell(row=grp_row_idx, column=1)
-		rm_group_cell.value = "Raw Material"
+		rm_group_cell.value = "Raw Material Consumed"
 		rm_group_cell.font = WHITE_BOLD
 		rm_group_cell.fill = FILL_RM_GROUP
 		rm_group_cell.alignment = ALIGN_CENTER
@@ -1255,6 +1255,6 @@ def get_export_excel(filters):
 	file_content = base64.b64encode(buf.read()).decode("utf-8")
 
 	timestamp = now_datetime().strftime("%Y%m%d_%H%M%S")
-	file_name = f"Customs_Export_Traceability_Report_{timestamp}.xlsx"
+	file_name = f"Consumption_Form_{timestamp}.xlsx"
 
 	return {"file_content": file_content, "file_name": file_name}

--- a/isnack/isnack/report/customs_export_traceability_report/customs_export_traceability_report_print.html
+++ b/isnack/isnack/report/customs_export_traceability_report/customs_export_traceability_report_print.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8"/>
-<title>Customs Export Traceability Report</title>
+<title>Consumption Form / Fiche de Côsommation</title>
 <style>
   body {
     font-family: Arial, Helvetica, sans-serif;
@@ -207,7 +207,7 @@
 </head>
 <body>
 <div class="report-header">
-  <h1>Customs Export Traceability Report</h1>
+  <h1>Consumption Form / Fiche de Côsommation</h1>
   <p class="company-name">{{ company }}</p>
   <p class="meta">Printed: {{ print_datetime }} &nbsp;&nbsp;|&nbsp;&nbsp; Printed by: {{ printed_by }}</p>
 </div>
@@ -327,7 +327,7 @@
 <table>
 <thead>
 <tr class="col-group-header">
-  <th colspan="4" class="col-group-rm">Raw Material</th>
+  <th colspan="4" class="col-group-rm">Raw Material Consumed</th>
   <th colspan="6" class="col-group-pc">Purchase / Customs</th>
 </tr>
 <tr>


### PR DESCRIPTION
Change the title shown in both the Print Traceability Report (HTML) and Export Traceability Report (xlsx) outputs from 'Customs Export Traceability Report' to 'Consumption Form / Fiche de Côsommation' (print <title>, print <h1>, and the Excel header row), and update the export filename to Consumption_Form_<timestamp>.xlsx to match.

Rename the column group that spans RM Item Code / RM Item Name / Consumed Qty / RM Batch No from 'Raw Material' to 'Raw Material Consumed' in both the print HTML and the Excel group header.

The report's internal name and the inner-button labels are unchanged.