### PR TITLE
Traceability report: PR Qty in stock UOM (use stock_qty)

### DIFF
--- a/isnack/isnack/report/customs_export_traceability_report/customs_export_traceability_report.py
+++ b/isnack/isnack/report/customs_export_traceability_report/customs_export_traceability_report.py
@@ -625,7 +625,7 @@ def _fetch_pr_details(pr_names):
 # ---------------------------------------------------------------------------
 
 def _fetch_pr_item_qty(pr_batch_keys):
-	"""Return {(pr_name, item_code, batch_no): received_qty}"""
+	"""Return {(pr_name, item_code, batch_no): received_qty_in_stock_uom}"""
 	if not pr_batch_keys:
 		return {}
 
@@ -634,10 +634,12 @@ def _fetch_pr_item_qty(pr_batch_keys):
 		if not (pr_name and item_code and batch_no):
 			continue
 
-		# Strategy a: direct batch_no on Purchase Receipt Item
+		# Strategy a: direct batch_no on Purchase Receipt Item.
+		# Use stock_qty so PR Qty is in the stock UOM (matches Consumed Qty /
+		# Balance Stock), not the purchase/transaction UOM.
 		direct_qty = frappe.db.sql(
 			"""
-			SELECT IFNULL(SUM(pri.qty), 0)
+			SELECT IFNULL(SUM(pri.stock_qty), 0)
 			FROM `tabPurchase Receipt Item` pri
 			WHERE pri.parent = %s
 			  AND pri.item_code = %s


### PR DESCRIPTION
PR Qty was summing Purchase Receipt Item.qty (purchase/transaction UOM), which could differ from the stock-UOM Consumed Qty and Balance Stock columns. Switch the primary lookup to SUM(pri.stock_qty) so PR Qty is in stock UOM. The Serial and Batch Entry fallback already records quantities in stock UOM, so it is unchanged.