### PR TITLE
Add Batch Explorer page: trace a batch across all transactions

### DIFF
--- a/isnack/isnack/page/batch_explorer/batch_explorer.css
+++ b/isnack/isnack/page/batch_explorer/batch_explorer.css
@@ -1,0 +1,334 @@
+/* ============================================================
+   Batch Explorer
+   ============================================================ */
+.be-container {
+	max-width: 980px;
+	margin: 0 auto;
+	padding: 4px 0 40px;
+}
+
+/* ---- summary card ---------------------------------------- */
+.be-card {
+	background: var(--card-bg, var(--fg-color));
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-lg, 10px);
+	box-shadow: var(--shadow-sm);
+	padding: 16px 18px;
+	margin-bottom: 16px;
+}
+.be-card-head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+.be-card-title {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+.be-batch-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 38px;
+	height: 38px;
+	border-radius: 9px;
+	background: var(--bg-blue, #e7f0ff);
+	color: var(--blue-500, #2e7fff);
+}
+.be-batch-name {
+	font-size: var(--text-xl, 1.1rem);
+	font-weight: 700;
+	color: var(--heading-color);
+}
+.be-batch-item {
+	font-size: var(--text-sm);
+	color: var(--text-muted);
+	margin-top: 1px;
+}
+.be-card-stats {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	margin-top: 16px;
+}
+.be-stat {
+	flex: 1 1 0;
+	min-width: 110px;
+	background: var(--subtle-fg, var(--bg-color));
+	border: 1px solid var(--border-color);
+	border-radius: 8px;
+	padding: 10px 12px;
+}
+.be-stat-val {
+	font-size: var(--text-lg, 1rem);
+	font-weight: 600;
+	color: var(--heading-color);
+}
+.be-stat-val small {
+	font-size: var(--text-sm);
+	color: var(--text-muted);
+	font-weight: 500;
+}
+.be-stat-lbl {
+	font-size: var(--text-xs, 0.72rem);
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--text-muted);
+	margin-top: 2px;
+}
+.be-danger {
+	color: var(--red-500, #e24c4c) !important;
+}
+.be-card-foot {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 14px;
+	padding-top: 12px;
+	border-top: 1px solid var(--border-color);
+	font-size: var(--text-sm);
+	color: var(--text-muted);
+}
+
+/* ---- chips ----------------------------------------------- */
+.be-chip {
+	font-size: var(--text-xs);
+	padding: 2px 8px;
+	border-radius: 20px;
+	background: var(--bg-light-gray, #f0f1f3);
+	color: var(--text-muted);
+	white-space: nowrap;
+}
+.be-chip.danger {
+	background: var(--bg-red, #fde9e9);
+	color: var(--red-600, #c0392b);
+}
+.be-chip.muted {
+	background: var(--bg-light-gray, #f0f1f3);
+}
+
+/* ---- toolbar / search ------------------------------------ */
+.be-toolbar {
+	margin-bottom: 10px;
+}
+.be-search {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	background: var(--control-bg, var(--bg-color));
+	border: 1px solid var(--border-color);
+	border-radius: 8px;
+	padding: 6px 12px;
+	color: var(--text-muted);
+}
+.be-search input {
+	flex: 1;
+	border: none;
+	background: transparent;
+	outline: none;
+	font-size: var(--text-md);
+	color: var(--text-color);
+}
+
+/* ---- tree ------------------------------------------------ */
+.be-tree {
+	position: relative;
+}
+.be-root-head {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-weight: 600;
+	color: var(--heading-color);
+	padding: 6px 0;
+}
+.be-root-dot {
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	background: var(--text-color);
+}
+.be-children {
+	margin-left: 9px;
+	padding-left: 18px;
+	border-left: 2px solid var(--border-color);
+}
+
+/* group node */
+.be-group {
+	margin: 6px 0;
+}
+.be-group-head {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 10px;
+	border: 1px solid var(--border-color);
+	border-left: 3px solid var(--be-color, #9e9e9e);
+	border-radius: 8px;
+	background: var(--card-bg, var(--fg-color));
+	cursor: pointer;
+	transition: background 0.12s ease;
+	user-select: none;
+}
+.be-group-head:hover {
+	background: var(--bg-color);
+}
+.be-group-dot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: var(--be-color, #9e9e9e);
+}
+.be-group-label {
+	font-weight: 600;
+	color: var(--heading-color);
+}
+.be-badge {
+	font-size: var(--text-xs);
+	font-weight: 600;
+	background: var(--be-color, #9e9e9e);
+	color: #fff;
+	border-radius: 20px;
+	padding: 1px 8px;
+	line-height: 1.5;
+}
+.be-group-qty {
+	margin-left: auto;
+	font-size: var(--text-sm);
+	font-weight: 600;
+	color: var(--text-muted);
+	font-variant-numeric: tabular-nums;
+}
+.be-caret {
+	display: inline-flex;
+	transition: transform 0.15s ease;
+	color: var(--text-muted);
+}
+.be-group.be-collapsed .be-caret {
+	transform: rotate(-90deg);
+}
+.be-group.be-collapsed .be-leaves {
+	display: none;
+}
+
+/* leaves */
+.be-leaves {
+	margin-left: 12px;
+	padding-left: 16px;
+	border-left: 2px dashed var(--border-color);
+	margin-top: 2px;
+}
+.be-leaf {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 8px 10px;
+	border-radius: 7px;
+	position: relative;
+	transition: background 0.12s ease;
+}
+.be-leaf:hover {
+	background: var(--bg-color);
+}
+.be-leaf-dot {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--be-color, #9e9e9e);
+	flex-shrink: 0;
+}
+.be-leaf-main {
+	flex: 1;
+	min-width: 0;
+}
+.be-leaf-name {
+	font-weight: 600;
+	color: var(--text-color);
+	cursor: pointer;
+}
+.be-leaf-name:hover {
+	color: var(--primary, #2e7fff);
+	text-decoration: underline;
+}
+.be-leaf-meta {
+	font-size: var(--text-sm);
+	color: var(--text-muted);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.be-leaf-side {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	flex-shrink: 0;
+}
+.be-qty {
+	font-weight: 600;
+	font-variant-numeric: tabular-nums;
+}
+.be-qty.be-in {
+	color: var(--green-600, #28a745);
+}
+.be-qty.be-out {
+	color: var(--red-500, #e24c4c);
+}
+.be-status {
+	font-size: var(--text-xs);
+}
+.be-leaf-user {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	color: var(--text-muted);
+	font-size: var(--text-sm);
+	max-width: 160px;
+}
+.be-leaf-user-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+/* ---- states ---------------------------------------------- */
+.be-loading,
+.be-empty {
+	text-align: center;
+	color: var(--text-muted);
+	padding: 60px 20px;
+}
+.be-empty-icon {
+	opacity: 0.4;
+	margin-bottom: 10px;
+}
+.be-empty-text {
+	font-size: var(--text-md);
+}
+.be-spinner {
+	display: inline-block;
+	width: 14px;
+	height: 14px;
+	border: 2px solid var(--border-color);
+	border-top-color: var(--primary, #2e7fff);
+	border-radius: 50%;
+	animation: be-spin 0.7s linear infinite;
+	vertical-align: middle;
+}
+@keyframes be-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+/* ---- responsive ------------------------------------------ */
+@media (max-width: 640px) {
+	.be-leaf-user-name {
+		display: none;
+	}
+	.be-stat {
+		min-width: calc(50% - 10px);
+	}
+}

--- a/isnack/isnack/page/batch_explorer/batch_explorer.js
+++ b/isnack/isnack/page/batch_explorer/batch_explorer.js
@@ -1,0 +1,313 @@
+frappe.provide("isnack");
+
+frappe.pages["batch-explorer"].on_page_load = function (wrapper) {
+	const page = frappe.ui.make_app_page({
+		parent: wrapper,
+		title: __("Batch Explorer"),
+		single_column: true,
+	});
+	wrapper.batch_explorer = new isnack.BatchExplorer(page);
+};
+
+frappe.pages["batch-explorer"].on_page_show = function (wrapper) {
+	// Support deep links: /app/batch-explorer/<batch-id>
+	const route = frappe.get_route();
+	if (route && route.length > 1 && wrapper.batch_explorer) {
+		wrapper.batch_explorer.load_from_route(route.slice(1).join("/"));
+	}
+};
+
+isnack.BatchExplorer = class BatchExplorer {
+	constructor(page) {
+		this.page = page;
+		this.data = null;
+		this.filter_text = "";
+		this.make();
+	}
+
+	make() {
+		this.controls();
+		this.layout();
+		this.show_empty(__("Select a batch to explore its journey through the system."));
+	}
+
+	controls() {
+		this.batch_field = this.page.add_field({
+			fieldname: "batch",
+			label: __("Batch"),
+			fieldtype: "Link",
+			options: "Batch",
+			change: () => {
+				const v = this.batch_field.get_value();
+				if (v) this.explore(v);
+			},
+		});
+
+		this.page.set_primary_action(
+			__("Explore"),
+			() => {
+				const v = this.batch_field.get_value();
+				if (v) this.explore(v);
+				else frappe.show_alert({ message: __("Please pick a batch"), indicator: "orange" });
+			},
+			"search"
+		);
+
+		this.expand_btn = this.page.add_button(__("Expand all"), () => this.toggle_all(true));
+		this.collapse_btn = this.page.add_button(__("Collapse all"), () => this.toggle_all(false));
+		this.set_tree_buttons(false);
+	}
+
+	set_tree_buttons(enabled) {
+		[this.expand_btn, this.collapse_btn].forEach((b) => b && b.prop("disabled", !enabled));
+	}
+
+	layout() {
+		this.body = $('<div class="be-container"></div>').appendTo(this.page.main);
+		this.$summary = $('<div class="be-summary"></div>').appendTo(this.body);
+		this.$toolbar = $('<div class="be-toolbar"></div>').appendTo(this.body);
+		this.$tree = $('<div class="be-tree"></div>').appendTo(this.body);
+	}
+
+	load_from_route(batch) {
+		if (!batch || batch === this.current_batch) return;
+		this.batch_field.set_value(batch);
+		this.explore(batch);
+	}
+
+	explore(batch) {
+		this.current_batch = batch;
+		this.set_tree_buttons(false);
+		this.$summary.empty();
+		this.$toolbar.empty();
+		this.$tree.html('<div class="be-loading"><span class="be-spinner"></span> ' + __("Tracing batch…") + "</div>");
+
+		frappe.call({
+			method: "isnack.isnack.page.batch_explorer.batch_explorer.get_batch_usage",
+			args: { batch_no: batch },
+			callback: (r) => {
+				if (!r || !r.message) return;
+				this.data = r.message;
+				this.render();
+			},
+			error: () => this.show_empty(__("Could not load batch usage.")),
+		});
+	}
+
+	show_empty(msg) {
+		this.$summary.empty();
+		this.$toolbar.empty();
+		this.$tree.html(
+			`<div class="be-empty">
+				<div class="be-empty-icon">${frappe.utils.icon("tree", "lg")}</div>
+				<div class="be-empty-text">${frappe.utils.escape_html(msg)}</div>
+			</div>`
+		);
+		this.set_tree_buttons(false);
+	}
+
+	render() {
+		const { batch, groups, summary } = this.data;
+		this.render_summary(batch, summary);
+		this.render_toolbar();
+		this.render_tree(batch, groups);
+		this.set_tree_buttons(groups.length > 0);
+	}
+
+	// ---- summary card -------------------------------------------------
+	render_summary(batch, summary) {
+		const fmt_date = (d) => (d ? frappe.datetime.str_to_user(d) : "—");
+		const expiry_cls = batch.expired ? "be-chip danger" : "be-chip";
+		const expiry_lbl = batch.expired ? __("Expired") : __("Expiry");
+
+		this.$summary.html(`
+			<div class="be-card">
+				<div class="be-card-head">
+					<div class="be-card-title">
+						<span class="be-batch-icon">${frappe.utils.icon("package", "md")}</span>
+						<div>
+							<div class="be-batch-name">${frappe.utils.escape_html(batch.name)}</div>
+							<div class="be-batch-item">
+								${frappe.utils.escape_html(batch.item || "")}
+								${batch.item_name ? "· " + frappe.utils.escape_html(batch.item_name) : ""}
+							</div>
+						</div>
+					</div>
+					${batch.disabled ? '<span class="be-chip muted">' + __("Disabled") + "</span>" : ""}
+				</div>
+				<div class="be-card-stats">
+					<div class="be-stat">
+						<div class="be-stat-val">${format_number(flt(batch.batch_qty))} <small>${frappe.utils.escape_html(batch.stock_uom || "")}</small></div>
+						<div class="be-stat-lbl">${__("Batch Qty")}</div>
+					</div>
+					<div class="be-stat">
+						<div class="be-stat-val">${fmt_date(batch.manufacturing_date)}</div>
+						<div class="be-stat-lbl">${__("Manufactured")}</div>
+					</div>
+					<div class="be-stat">
+						<div class="be-stat-val ${batch.expired ? "be-danger" : ""}">${fmt_date(batch.expiry_date)}</div>
+						<div class="be-stat-lbl">${expiry_lbl}</div>
+					</div>
+					<div class="be-stat">
+						<div class="be-stat-val">${summary.transactions}</div>
+						<div class="be-stat-lbl">${__("Transactions")}</div>
+					</div>
+					<div class="be-stat">
+						<div class="be-stat-val">${summary.doctypes}</div>
+						<div class="be-stat-lbl">${__("Document Types")}</div>
+					</div>
+				</div>
+				<div class="be-card-foot">
+					${frappe.avatar(batch.owner, "avatar-small")}
+					<span>${__("Created by")} <b>${frappe.utils.escape_html(batch.owner_name || batch.owner || "")}</b></span>
+				</div>
+			</div>
+		`);
+	}
+
+	render_toolbar() {
+		const $search = $(`
+			<div class="be-search">
+				${frappe.utils.icon("search", "sm")}
+				<input type="text" placeholder="${__("Filter documents, users, status…")}" />
+			</div>
+		`);
+		const self = this;
+		$search.find("input").on("input", function () {
+			self.filter_text = (this.value || "").toLowerCase();
+			self.apply_filter();
+		});
+		this.$toolbar.append($search);
+	}
+
+	// ---- tree ---------------------------------------------------------
+	render_tree(batch, groups) {
+		this.$tree.empty();
+		if (!groups.length) {
+			this.show_empty(__("This batch has not been used in any transaction yet."));
+			return;
+		}
+
+		const $root = $('<div class="be-node be-root"></div>').appendTo(this.$tree);
+		$(`
+			<div class="be-root-head">
+				<span class="be-root-dot"></span>
+				<span class="be-root-label">${__("Batch")} · ${frappe.utils.escape_html(batch.name)}</span>
+			</div>
+		`).appendTo($root);
+
+		const $children = $('<div class="be-children"></div>').appendTo($root);
+
+		groups.forEach((group) => this.render_group(group, $children));
+	}
+
+	render_group(group, $parent) {
+		const $group = $('<div class="be-group"></div>').appendTo($parent);
+
+		const total = group.total_qty != null
+			? `<span class="be-group-qty">${format_number(group.total_qty)}</span>`
+			: "";
+
+		const $head = $(`
+			<div class="be-group-head" style="--be-color:${group.color}">
+				<span class="be-caret">${frappe.utils.icon("es-line-down", "xs")}</span>
+				<span class="be-group-dot"></span>
+				<span class="be-group-label">${frappe.utils.escape_html(group.label)}</span>
+				<span class="be-badge">${group.count}</span>
+				${total}
+			</div>
+		`).appendTo($group);
+
+		const $leaves = $('<div class="be-leaves"></div>').appendTo($group);
+		group.nodes.forEach((node) => this.render_leaf(node, group, $leaves));
+
+		$head.on("click", () => $group.toggleClass("be-collapsed"));
+	}
+
+	render_leaf(node, group, $parent) {
+		const status = this.status_indicator(node);
+		let qty = "";
+		if (node.qty != null && node.direction) {
+			const cls = node.direction === "in" ? "be-in" : "be-out";
+			const sign = node.direction === "in" ? "+" : "";
+			qty = `<span class="be-qty ${cls}">${sign}${format_number(node.qty)}</span>`;
+		}
+		const meta_bits = [];
+		if (node.date) meta_bits.push(frappe.datetime.str_to_user(node.date));
+		if (node.party) meta_bits.push(frappe.utils.escape_html(node.party));
+		if (node.extra) meta_bits.push(frappe.utils.escape_html(node.extra));
+
+		const $leaf = $(`
+			<div class="be-leaf" style="--be-color:${group.color}">
+				<span class="be-leaf-dot"></span>
+				<div class="be-leaf-main">
+					<a class="be-leaf-name" href="/app/${frappe.router.slug(node.doctype)}/${encodeURIComponent(node.name)}">
+						${frappe.utils.escape_html(node.name)}
+					</a>
+					<div class="be-leaf-meta">${meta_bits.join(" · ")}</div>
+				</div>
+				<div class="be-leaf-side">
+					${qty}
+					${status}
+					<span class="be-leaf-user" title="${__("Created by")} ${frappe.utils.escape_html(node.owner_name || "")}">
+						${frappe.avatar(node.owner, "avatar-small")}
+						<span class="be-leaf-user-name">${frappe.utils.escape_html(node.owner_name || "")}</span>
+					</span>
+				</div>
+			</div>
+		`).appendTo($parent);
+
+		// searchable haystack
+		$leaf.attr(
+			"data-search",
+			[node.name, node.owner_name, node.status, node.party, node.extra, group.label]
+				.filter(Boolean)
+				.join(" ")
+				.toLowerCase()
+		);
+
+		$leaf.find(".be-leaf-name").on("click", (e) => {
+			e.preventDefault();
+			frappe.set_route("Form", node.doctype, node.name);
+		});
+	}
+
+	status_indicator(node) {
+		const map = {
+			Draft: "gray",
+			Submitted: "blue",
+			Cancelled: "red",
+			Completed: "green",
+			"Not Started": "orange",
+			"In Process": "orange",
+			Paid: "green",
+			"To Bill": "orange",
+			"To Deliver": "orange",
+			Closed: "green",
+			Stopped: "red",
+			Return: "gray",
+		};
+		const color = map[node.status] || (node.docstatus === 2 ? "red" : node.docstatus === 1 ? "blue" : "gray");
+		if (!node.status) return "";
+		return `<span class="be-status indicator-pill ${color}">${frappe.utils.escape_html(node.status)}</span>`;
+	}
+
+	// ---- interactions -------------------------------------------------
+	toggle_all(expand) {
+		this.$tree.find(".be-group").toggleClass("be-collapsed", !expand);
+	}
+
+	apply_filter() {
+		const q = this.filter_text;
+		this.$tree.find(".be-leaf").each(function () {
+			const hay = $(this).attr("data-search") || "";
+			$(this).toggle(!q || hay.indexOf(q) !== -1);
+		});
+		// hide groups with no visible leaves while filtering
+		this.$tree.find(".be-group").each(function () {
+			const visible = $(this).find(".be-leaf:visible").length;
+			$(this).toggle(!q || visible > 0);
+			if (q && visible > 0) $(this).removeClass("be-collapsed");
+		});
+	}
+};

--- a/isnack/isnack/page/batch_explorer/batch_explorer.json
+++ b/isnack/isnack/page/batch_explorer/batch_explorer.json
@@ -1,0 +1,19 @@
+{
+ "content": null,
+ "creation": "2026-06-16 21:00:00.000000",
+ "docstatus": 0,
+ "doctype": "Page",
+ "idx": 0,
+ "modified": "2026-06-16 21:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Isnack",
+ "name": "batch-explorer",
+ "owner": "Administrator",
+ "page_name": "batch-explorer",
+ "roles": [],
+ "script": null,
+ "standard": "Yes",
+ "style": null,
+ "system_page": 0,
+ "title": "Batch Explorer"
+}

--- a/isnack/isnack/page/batch_explorer/batch_explorer.py
+++ b/isnack/isnack/page/batch_explorer/batch_explorer.py
@@ -1,0 +1,308 @@
+"""Batch Explorer backend.
+
+Given a Batch, resolve every transaction the batch participated in and return a
+tree-friendly structure for the Batch Explorer desk page.
+
+Resolution strategy
+--------------------
+1. Stock Ledger Entry (SLE) is the canonical record of every stock movement.
+   For the batch we collect the distinct ``(voucher_type, voucher_no)`` pairs,
+   handling both the legacy ``batch_no`` column and the v15
+   ``serial_and_batch_bundle`` -> ``Serial and Batch Entry`` link.
+2. From the stock vouchers we *derive* the upstream/related documents that do
+   not themselves carry stock (and therefore have no SLE):
+       - Work Orders        (from Stock Entries linked to a Work Order)
+       - Sales Orders       (from Sales Invoice / Delivery Note items)
+       - Purchase Orders    (from Purchase Receipt / Purchase Invoice items)
+3. Each node is enriched with the creating user, status and a signed quantity.
+
+All per-document reads go through ``frappe.get_all`` so the caller only ever
+sees documents they are permitted to read.
+"""
+
+from __future__ import annotations
+
+import frappe
+from frappe import _
+from frappe.utils import flt, getdate, nowdate
+
+# Display metadata per doctype: colour + logical ordering for the tree.
+DOCTYPE_META = {
+	"Work Order": {"color": "#7c4dff", "order": 1, "category": "Manufacturing"},
+	"Stock Entry": {"color": "#607d8b", "order": 2, "category": "Stock"},
+	"Stock Reconciliation": {"color": "#90a4ae", "order": 3, "category": "Stock"},
+	"Purchase Order": {"color": "#fb8c00", "order": 4, "category": "Purchasing"},
+	"Purchase Receipt": {"color": "#8d6e63", "order": 5, "category": "Purchasing"},
+	"Purchase Invoice": {"color": "#ef5350", "order": 6, "category": "Purchasing"},
+	"Sales Order": {"color": "#42a5f5", "order": 7, "category": "Sales"},
+	"Delivery Note": {"color": "#26a69a", "order": 8, "category": "Sales"},
+	"Sales Invoice": {"color": "#66bb6a", "order": 9, "category": "Sales"},
+	"Packing Slip": {"color": "#5c6bc0", "order": 10, "category": "Sales"},
+	"Pick List": {"color": "#26c6da", "order": 11, "category": "Sales"},
+}
+
+_DOCSTATUS_LABEL = {0: "Draft", 1: "Submitted", 2: "Cancelled"}
+
+
+@frappe.whitelist()
+def get_batch_usage(batch_no: str | None = None):
+	"""Return ``{batch, groups, summary}`` describing where ``batch_no`` was used."""
+	batch_no = (batch_no or "").strip()
+	if not batch_no:
+		frappe.throw(_("Please select a Batch."))
+
+	if not frappe.has_permission("Batch", "read"):
+		raise frappe.PermissionError(_("Not permitted to read Batch."))
+
+	batch = frappe.db.get_value(
+		"Batch",
+		batch_no,
+		["name", "item", "batch_qty", "manufacturing_date", "expiry_date", "disabled", "owner", "creation"],
+		as_dict=True,
+	)
+	if not batch:
+		frappe.throw(_("Batch {0} not found.").format(frappe.bold(batch_no)))
+
+	item_info = (
+		frappe.db.get_value("Item", batch.item, ["item_name", "stock_uom"], as_dict=True) or frappe._dict()
+	)
+	batch.item_name = item_info.get("item_name")
+	batch.stock_uom = item_info.get("stock_uom")
+	batch.owner_name = _user_name(batch.owner)
+	batch.expired = bool(batch.expiry_date and getdate(batch.expiry_date) < getdate(nowdate()))
+
+	# 1) direct stock vouchers from the Stock Ledger
+	direct = _direct_vouchers(batch_no)
+
+	# 2) derive related Work Orders / Sales Orders / Purchase Orders
+	derived = _derived_vouchers(direct)
+
+	# 3) build the grouped node tree
+	groups = []
+	for doctype in set(list(direct.keys()) + list(derived.keys())):
+		names_qty = dict(direct.get(doctype, {}))
+		for name in derived.get(doctype, set()):
+			names_qty.setdefault(name, {"qty": None, "date": None})
+
+		nodes = _build_nodes(doctype, names_qty)
+		if not nodes:
+			continue
+		qtys = [flt(n["qty"]) for n in nodes if n["qty"] is not None]
+		meta = DOCTYPE_META.get(doctype, {})
+		groups.append(
+			{
+				"doctype": doctype,
+				"label": _(doctype),
+				"color": meta.get("color", "#9e9e9e"),
+				"category": meta.get("category", "Other"),
+				"count": len(nodes),
+				"total_qty": sum(qtys) if qtys else None,
+				"nodes": nodes,
+			}
+		)
+
+	groups.sort(key=lambda g: (DOCTYPE_META.get(g["doctype"], {}).get("order", 99), g["doctype"]))
+
+	return {
+		"batch": batch,
+		"groups": groups,
+		"summary": {
+			"transactions": sum(g["count"] for g in groups),
+			"doctypes": len(groups),
+		},
+	}
+
+
+# ---------------------------------------------------------------------------
+# Step 1 - direct stock vouchers via Stock Ledger Entry
+# ---------------------------------------------------------------------------
+
+def _direct_vouchers(batch_no: str) -> dict[str, dict]:
+	"""Return {doctype: {voucher_no: {qty, date}}} from the Stock Ledger."""
+	rows = frappe.db.sql(
+		"""
+		SELECT
+			sle.voucher_type            AS voucher_type,
+			sle.voucher_no              AS voucher_no,
+			SUM(sle.actual_qty)         AS qty,
+			MIN(sle.posting_date)       AS posting_date
+		FROM `tabStock Ledger Entry` sle
+		WHERE sle.is_cancelled = 0
+		  AND (
+			sle.batch_no = %(b)s
+			OR EXISTS (
+				SELECT 1 FROM `tabSerial and Batch Entry` sbe
+				WHERE sbe.parent = sle.serial_and_batch_bundle
+				  AND sbe.batch_no = %(b)s
+			)
+		  )
+		GROUP BY sle.voucher_type, sle.voucher_no
+		ORDER BY MIN(sle.posting_date), sle.voucher_no
+		""",
+		{"b": batch_no},
+		as_dict=True,
+	)
+
+	direct: dict[str, dict] = {}
+	for r in rows:
+		if not r.voucher_type or not r.voucher_no:
+			continue
+		direct.setdefault(r.voucher_type, {})[r.voucher_no] = {
+			"qty": flt(r.qty),
+			"date": r.posting_date,
+		}
+	return direct
+
+
+# ---------------------------------------------------------------------------
+# Step 2 - derive related documents that carry no stock of their own
+# ---------------------------------------------------------------------------
+
+def _derived_vouchers(direct: dict[str, dict]) -> dict[str, set]:
+	derived: dict[str, set] = {}
+
+	se_names = list(direct.get("Stock Entry", {}).keys())
+	dn_names = list(direct.get("Delivery Note", {}).keys())
+	si_names = list(direct.get("Sales Invoice", {}).keys())
+	pr_names = list(direct.get("Purchase Receipt", {}).keys())
+	pi_names = list(direct.get("Purchase Invoice", {}).keys())
+
+	# Work Orders linked to the Stock Entries (manufacture, transfer, issue ...)
+	if se_names:
+		work_orders = {
+			r.work_order
+			for r in frappe.get_all(
+				"Stock Entry",
+				filters={"name": ["in", se_names], "work_order": ["is", "set"]},
+				fields=["work_order"],
+			)
+			if r.work_order
+		}
+		if work_orders:
+			derived["Work Order"] = work_orders
+
+	# Sales Orders behind the Sales Invoices / Delivery Notes
+	sales_orders: set[str] = set()
+	sales_orders |= _child_links("Sales Invoice Item", si_names, "sales_order")
+	sales_orders |= _child_links("Delivery Note Item", dn_names, "against_sales_order")
+	if sales_orders:
+		derived["Sales Order"] = sales_orders
+
+	# Purchase Orders behind the Purchase Receipts / Purchase Invoices
+	purchase_orders: set[str] = set()
+	purchase_orders |= _child_links("Purchase Receipt Item", pr_names, "purchase_order")
+	purchase_orders |= _child_links("Purchase Invoice Item", pi_names, "purchase_order")
+	if purchase_orders:
+		derived["Purchase Order"] = purchase_orders
+
+	return derived
+
+
+def _child_links(child_doctype: str, parents: list[str], fieldname: str) -> set[str]:
+	"""Return the distinct non-empty ``fieldname`` values from child rows."""
+	if not parents:
+		return set()
+	rows = frappe.get_all(
+		child_doctype,
+		filters={"parent": ["in", parents], fieldname: ["is", "set"]},
+		fields=[fieldname],
+		distinct=True,
+	)
+	return {r.get(fieldname) for r in rows if r.get(fieldname)}
+
+
+# ---------------------------------------------------------------------------
+# Step 3 - build display nodes for a doctype (permission-checked)
+# ---------------------------------------------------------------------------
+
+# candidate detail fields per doctype, used only when the field actually exists
+_OPTIONAL_FIELDS = [
+	"status",
+	"posting_date",
+	"transaction_date",
+	"customer",
+	"customer_name",
+	"supplier",
+	"supplier_name",
+	"production_item",
+	"item_name",
+	"qty",
+	"purpose",
+	"stock_entry_type",
+]
+
+
+def _build_nodes(doctype: str, names_qty: dict[str, dict]) -> list[dict]:
+	if not names_qty:
+		return []
+
+	meta = frappe.get_meta(doctype)
+	fields = ["name", "owner", "creation", "docstatus"]
+	fields += [f for f in _OPTIONAL_FIELDS if meta.has_field(f)]
+	fields = list(dict.fromkeys(fields))
+
+	rows = frappe.get_all(doctype, filters={"name": ["in", list(names_qty.keys())]}, fields=fields)
+	if not rows:
+		return []
+
+	owner_names = _user_names({r.owner for r in rows})
+
+	nodes = []
+	for r in rows:
+		qd = names_qty.get(r.name, {})
+		qty = qd.get("qty")
+		date = qd.get("date") or r.get("posting_date") or r.get("transaction_date")
+		if not date and r.get("creation"):
+			date = getdate(r.creation)
+
+		party = (
+			r.get("customer_name")
+			or r.get("customer")
+			or r.get("supplier_name")
+			or r.get("supplier")
+		)
+		extra = r.get("stock_entry_type") or r.get("purpose") or r.get("production_item")
+
+		nodes.append(
+			{
+				"doctype": doctype,
+				"name": r.name,
+				"qty": flt(qty) if qty is not None else None,
+				"direction": _direction(qty),
+				"date": str(date) if date else None,
+				"owner": r.owner,
+				"owner_name": owner_names.get(r.owner, r.owner),
+				"docstatus": r.docstatus,
+				"status": r.get("status") or _DOCSTATUS_LABEL.get(r.docstatus, ""),
+				"party": party,
+				"extra": extra,
+			}
+		)
+
+	nodes.sort(key=lambda n: (n["date"] or "", n["name"]))
+	return nodes
+
+
+def _direction(qty) -> str | None:
+	q = flt(qty)
+	if qty is None or q == 0:
+		return None
+	return "in" if q > 0 else "out"
+
+
+# ---------------------------------------------------------------------------
+# user-name helpers
+# ---------------------------------------------------------------------------
+
+def _user_name(user: str | None) -> str | None:
+	if not user:
+		return None
+	return frappe.db.get_value("User", user, "full_name") or user
+
+
+def _user_names(users: set[str]) -> dict[str, str]:
+	users = {u for u in users if u}
+	if not users:
+		return {}
+	rows = frappe.get_all("User", filters={"name": ["in", list(users)]}, fields=["name", "full_name"])
+	return {r.name: (r.full_name or r.name) for r in rows}

--- a/isnack/isnack/workspace/factory/factory.json
+++ b/isnack/isnack/workspace/factory/factory.json
@@ -129,9 +129,19 @@
    "link_type": "Report",
    "onboard": 0,
    "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Batch Explorer",
+   "link_count": 0,
+   "link_to": "batch-explorer",
+   "link_type": "Page",
+   "onboard": 0,
+   "type": "Link"
   }
  ],
- "modified": "2026-06-02 20:02:55.881237",
+ "modified": "2026-06-16 21:00:00.000000",
  "modified_by": "Administrator",
  "module": "Isnack",
  "name": "Factory",


### PR DESCRIPTION
New desk page 'Batch Explorer' (isnack/page/batch_explorer) that, given a Batch, renders a collapsible tree of every transaction the batch took part in, grouped by document type and showing the creating user, status, date and signed quantity.

Backend (batch_explorer.py):
- Resolves direct stock vouchers from the Stock Ledger Entry, handling both the legacy batch_no column and the v15 serial_and_batch_bundle / Serial and Batch Entry link.
- Derives related Work Orders (via linked Stock Entries), Sales Orders (via SI / DN items) and Purchase Orders (via PR / PI items).
- Enriches each node with creator full name and status; all per-doc reads go through frappe.get_all so results respect read permissions.

Frontend (batch_explorer.js/.css):
- Batch picker + Explore action, deep-linkable via /app/batch-explorer/<batch>.
- Summary card (item, qty, mfg/expiry with expiry warning, totals, creator), colour-coded collapsible tree, expand/collapse all, and live text filter.
- Theme-aware styling (light/dark via CSS variables).

Also added a 'Batch Explorer' link under the Stock card of the Factory workspace.