### PR TITLE
fix(maintenance): add missing top-level name to Maintenance workspace

### DIFF
--- a/isnack/isnack/workspace/maintenance/maintenance.json
+++ b/isnack/isnack/workspace/maintenance/maintenance.json
@@ -33,6 +33,7 @@
  "modified": "2026-06-17 09:00:00.000000",
  "modified_by": "Administrator",
  "module": "Isnack",
+ "name": "Maintenance",
  "number_cards": [],
  "owner": "Administrator",
  "parent_page": "",


### PR DESCRIPTION
The Workspace JSON lacked a top-level "name" key, causing `bench migrate` to fail with KeyError: 'name' in import_file_by_path during module sync.


Claude-Session: https://claude.ai/code/session_01DFvNaVzhCkAgb2fLoUmzXy