### PR TITLE
fix(maintenance): allow zero-day escalation rule (Due today)

### DIFF
--- a/isnack/isnack/doctype/maintenance_escalation_rule/maintenance_escalation_rule.py
+++ b/isnack/isnack/doctype/maintenance_escalation_rule/maintenance_escalation_rule.py
@@ -4,10 +4,11 @@ from frappe.model.document import Document
 
 class MaintenanceEscalationRule(Document):
     def validate(self):
-        if not (self.days_before_due or self.days_after_due):
-            frappe.throw(
-                frappe._("Set either 'Days Before Due' or 'Days After Due'.")
-            )
+        # days_before_due = days_after_due = 0 is valid: it means "due today".
+        if (self.days_before_due or 0) < 0:
+            frappe.throw(frappe._("'Days Before Due' cannot be negative."))
+        if (self.days_after_due or 0) < 0:
+            frappe.throw(frappe._("'Days After Due' cannot be negative."))
         if not (
             self.notify_technician
             or self.notify_maintenance_manager


### PR DESCRIPTION
The default "Due today" escalation rule sets both days_before_due and days_after_due to 0, which is a meaningful rule (the scheduler treats both-zero as "due today"). The validate() check wrongly rejected it, breaking the seed_maintenance_escalation_rules patch during migrate. Now only negative day values are rejected.


Claude-Session: https://claude.ai/code/session_01DFvNaVzhCkAgb2fLoUmzXy