### PR TITLE
Add semi-finished goods classification and default quantities

### DIFF
--- a/isnack/api/mes_ops.py
+++ b/isnack/api/mes_ops.py
@@ -2620,10 +2620,11 @@ def get_ended_work_orders(lines: str = None):
             if (_line_for_work_order(wo["name"]) in line_list)
         ]
     
-    # Enrich with item names
+    # Enrich with item names and FG/SFG classification (by Item Group, see _is_fg)
     for wo in work_orders:
         wo["item_name"] = frappe.db.get_value("Item", wo["production_item"], "item_name") or wo["production_item"]
-    
+        wo["is_sfg"] = not _is_fg(wo["production_item"])
+
     return {"work_orders": work_orders}
 
 @frappe.whitelist()

--- a/isnack/isnack/page/operator_hub/operator_hub.js
+++ b/isnack/isnack/page/operator_hub/operator_hub.js
@@ -2668,6 +2668,7 @@ function init_operator_hub($root) {
           work_orders: [],
           packaging_items: [],
           has_batch_no: false,
+          is_sfg: !!wo.is_sfg,
         };
         groupByKey.set(key, g);
         productGroups.push(g);
@@ -2723,7 +2724,11 @@ function init_operator_hub($root) {
         ? `Production Quantities — ${g.item_name}`
         : 'Production Quantities';
       fields.push({ fieldtype: 'Section Break', label: quantitiesLabel });
-      fields.push({ label:'Total Good Qty',   fieldname:`g${gIdx}_good_qty`,   fieldtype:'Float', reqd:1, default: 0 });
+      // Semi-finished groups default to the sum of their WO planned quantities
+      // (the operator adjusts if actual output differed); finished goods start
+      // at 0 because the actual carton count must be entered.
+      const plannedTotal = g.work_orders.reduce((sum, wo) => sum + (parseFloat(wo.qty) || 0), 0);
+      fields.push({ label:'Total Good Qty',   fieldname:`g${gIdx}_good_qty`,   fieldtype:'Float', reqd:1, default: g.is_sfg ? plannedTotal : 0 });
       fields.push({ fieldtype: 'Column Break' });
       fields.push({ label:'Total Reject Qty', fieldname:`g${gIdx}_reject_qty`, fieldtype:'Float', default: 0 });
       fields.push({ fieldtype: 'Column Break' });


### PR DESCRIPTION
## Summary
This change adds support for distinguishing between semi-finished goods (SFG) and finished goods (FG) in the operator hub, and automatically defaults the "Total Good Qty" field based on the product type.

## Key Changes
- **Backend enrichment**: Modified `get_ended_work_orders()` in `mes_ops.py` to classify each work order as SFG or FG using the `_is_fg()` helper function, adding an `is_sfg` flag to each work order
- **Frontend classification**: Updated the operator hub to track the `is_sfg` flag when grouping work orders by product
- **Smart defaults**: Changed the "Total Good Qty" field default behavior:
  - **Semi-finished goods**: Defaults to the sum of planned quantities from all work orders in the group (operator adjusts if actual output differed)
  - **Finished goods**: Defaults to 0 (requires operator to enter actual carton count)

## Implementation Details
- The `is_sfg` classification is determined by checking if the production item is NOT a finished good (using the existing `_is_fg()` function)
- The planned total is calculated by summing the `qty` field from all work orders in a product group
- Added explanatory comments in the frontend code clarifying the rationale for different default behaviors

https://claude.ai/code/session_01QoeMrEMdUh83ntHYeznEZi