### PR TITLE
Proforma (Sales Order) & Quotation: set modified to current Malta time

### DIFF
--- a/isnack/isnack/print_format/proforma_sales_invoice/proforma_sales_invoice.json
+++ b/isnack/isnack/print_format/proforma_sales_invoice/proforma_sales_invoice.json
@@ -16,7 +16,7 @@
  "margin_left": 15.0,
  "margin_right": 15.0,
  "margin_top": 15.0,
- "modified": "2026-06-17 12:30:00.000000",
+ "modified": "2026-07-03 20:03:09.000000",
  "modified_by": "Administrator",
  "module": "Isnack",
  "name": "Proforma Sales Invoice",

--- a/isnack/isnack/print_format/quotation/quotation.json
+++ b/isnack/isnack/print_format/quotation/quotation.json
@@ -16,7 +16,7 @@
  "margin_left": 15.0,
  "margin_right": 15.0,
  "margin_top": 15.0,
- "modified": "2026-06-17 12:30:00.000000",
+ "modified": "2026-07-03 20:03:09.000000",
  "modified_by": "Administrator",
  "module": "Isnack",
  "name": "Quotation",


### PR DESCRIPTION
The prior alignment commit used a placeholder modified timestamp. Bump both formats' modified to the actual current Malta (CEST, UTC+2) time.