### PR TITLE
Pallet manifest: filter the Batch picker to the item's selected batches

### DIFF
--- a/isnack/api/delivery_note_pallets.py
+++ b/isnack/api/delivery_note_pallets.py
@@ -279,6 +279,32 @@ def _build_pallet_suggestion(rows: list[dict]) -> dict:
 
 
 @frappe.whitelist()
+def get_bundle_batches(bundles) -> dict:
+    """Batch numbers contained in the given Serial and Batch Bundles.
+
+    Used by the Delivery Note form to filter the pallet manifest's Batch
+    picker down to the batches actually selected on the item rows, which may
+    live in a Serial and Batch Bundle rather than the row's batch_no field.
+    Returns ``{bundle_name: [batch_no, ...]}``.
+    """
+    bundles = frappe.parse_json(bundles) if isinstance(bundles, str) else bundles
+    if not bundles:
+        return {}
+
+    result: dict = {}
+    for entry in frappe.get_all(
+        "Serial and Batch Entry",
+        filters={"parent": ["in", bundles], "batch_no": ["is", "set"]},
+        fields=["parent", "batch_no"],
+        parent_doctype="Serial and Batch Bundle",
+    ):
+        result.setdefault(entry.parent, [])
+        if entry.batch_no not in result[entry.parent]:
+            result[entry.parent].append(entry.batch_no)
+    return result
+
+
+@frappe.whitelist()
 def suggest_pallets(doc) -> dict:
     """Build a pallet-manifest suggestion for a (possibly unsaved) Delivery Note.
 

--- a/isnack/api/test_delivery_note_pallets.py
+++ b/isnack/api/test_delivery_note_pallets.py
@@ -9,6 +9,7 @@ from isnack.api.delivery_note_pallets import (
     _build_pallet_suggestion,
     _pallet_conversion_factor,
     calculate_delivery_note_pallets,
+    get_bundle_batches,
     get_delivery_note_pallet_conversion,
     validate_delivery_note_pallets,
 )
@@ -375,6 +376,28 @@ class TestValidateDeliveryNotePallets(unittest.TestCase):
         )
         validate_delivery_note_pallets(doc)
         mock_msgprint.assert_called_once()
+
+
+class TestGetBundleBatches(unittest.TestCase):
+    """Tests for the Serial and Batch Bundle -> batch numbers helper."""
+
+    def test_empty_input_returns_empty(self):
+        self.assertEqual(get_bundle_batches([]), {})
+        self.assertEqual(get_bundle_batches(None), {})
+
+    @patch("isnack.api.delivery_note_pallets.frappe.get_all")
+    def test_batches_grouped_and_deduplicated_per_bundle(self, mock_get_all):
+        mock_get_all.return_value = [
+            _FakeRow(parent="SABB-001", batch_no="AAA-005"),
+            _FakeRow(parent="SABB-001", batch_no="ZZZ-005"),
+            _FakeRow(parent="SABB-001", batch_no="AAA-005"),
+            _FakeRow(parent="SABB-002", batch_no="BBB-001"),
+        ]
+        result = get_bundle_batches(["SABB-001", "SABB-002"])
+        self.assertEqual(result["SABB-001"], ["AAA-005", "ZZZ-005"])
+        self.assertEqual(result["SABB-002"], ["BBB-001"])
+        kwargs = mock_get_all.call_args.kwargs
+        self.assertEqual(kwargs.get("parent_doctype"), "Serial and Batch Bundle")
 
 
 if __name__ == "__main__":

--- a/isnack/public/js/delivery_note.js
+++ b/isnack/public/js/delivery_note.js
@@ -17,12 +17,22 @@ frappe.ui.form.on("Delivery Note", {
         // Re-assert the Pallet Type filter (allowed UOMs may already be cached).
         isnack_dn_set_pallet_type_query(frm);
         isnack_dn_add_build_pallets_button(frm);
+        isnack_dn_refresh_batch_cache(frm);
     },
 });
 
 frappe.ui.form.on("Delivery Note Item", {
     item_code(frm, cdt, cdn) {
         isnack_dn_calc_pallet_qty(frm, cdt, cdn);
+        isnack_dn_refresh_batch_cache(frm);
+    },
+
+    batch_no(frm) {
+        isnack_dn_refresh_batch_cache(frm);
+    },
+
+    serial_and_batch_bundle(frm) {
+        isnack_dn_refresh_batch_cache(frm);
     },
 
     qty(frm, cdt, cdn) {
@@ -139,7 +149,9 @@ function isnack_dn_set_pallet_type_query(frm) {
         filters: { name: ["in", allowed] },
     }));
     // Same restriction for the Pallets table (field may not be migrated yet),
-    // plus limit its Item picker to items actually on this Delivery Note.
+    // plus limit its Item picker to items actually on this Delivery Note and
+    // its Batch picker to that item's batches — ideally only the batches
+    // selected on the item rows (including Serial and Batch Bundle contents).
     if (frm.fields_dict.custom_pallets) {
         frm.set_query("pallet_type", "custom_pallets", () => ({
             filters: { name: ["in", allowed] },
@@ -149,7 +161,67 @@ function isnack_dn_set_pallet_type_query(frm) {
                 name: ["in", (frm.doc.items || []).map((i) => i.item_code)],
             },
         }));
+        frm.set_query("batch_no", "custom_pallets", (doc, cdt, cdn) => {
+            const row = locals[cdt] && locals[cdt][cdn];
+            const item_code = row && row.item_code;
+            if (!item_code) {
+                return {
+                    filters: {
+                        item: ["in", (frm.doc.items || []).map((i) => i.item_code)],
+                    },
+                };
+            }
+            const known =
+                (frm.__isnack_dn_batches_by_item || {})[item_code] || [];
+            if (known.length) {
+                return { filters: { name: ["in", known] } };
+            }
+            return { filters: { item: item_code } };
+        });
     }
+}
+
+// Cache the batches selected on the item rows per item, so the pallet
+// manifest's Batch picker can be narrowed to them. Batches may sit directly
+// on the row (batch_no) or inside its Serial and Batch Bundle, whose entries
+// are fetched server-side.
+function isnack_dn_refresh_batch_cache(frm) {
+    const by_item = {};
+    const bundle_rows = [];
+    (frm.doc.items || []).forEach((item) => {
+        if (!item.item_code) {
+            return;
+        }
+        by_item[item.item_code] = by_item[item.item_code] || [];
+        if (item.batch_no && !by_item[item.item_code].includes(item.batch_no)) {
+            by_item[item.item_code].push(item.batch_no);
+        }
+        if (item.serial_and_batch_bundle) {
+            bundle_rows.push([item.item_code, item.serial_and_batch_bundle]);
+        }
+    });
+
+    if (!bundle_rows.length) {
+        frm.__isnack_dn_batches_by_item = by_item;
+        return;
+    }
+
+    frappe
+        .call({
+            method: "isnack.api.delivery_note_pallets.get_bundle_batches",
+            args: { bundles: bundle_rows.map((b) => b[1]) },
+        })
+        .then((r) => {
+            const by_bundle = (r && r.message) || {};
+            bundle_rows.forEach(([item_code, bundle]) => {
+                (by_bundle[bundle] || []).forEach((batch) => {
+                    if (!by_item[item_code].includes(batch)) {
+                        by_item[item_code].push(batch);
+                    }
+                });
+            });
+            frm.__isnack_dn_batches_by_item = by_item;
+        });
 }
 
 // "Build Pallets from Items": prefill the pallet manifest from the per-row


### PR DESCRIPTION
The manifest's batch_no field had no link query, so the picker offered every batch in the system. It is now narrowed in two layers:
- Ideal: only the batches actually selected on the Delivery Note item rows for that item - from the row batch_no or the row's Serial and Batch Bundle (entries fetched via a new whitelisted get_bundle_batches helper and cached on the form; refreshed on refresh/item/batch/bundle changes).
- Floor: when no row batches are known yet, filter by the allocation row's item; with no item picked, by the items on the document.