### PR TITLE
Pallet manifest: block expired batches and over-allocation vs stock

### DIFF
--- a/isnack/api/delivery_note_pallets.py
+++ b/isnack/api/delivery_note_pallets.py
@@ -18,7 +18,7 @@ from typing import Optional
 
 import frappe
 from frappe import _
-from frappe.utils import cint, flt
+from frappe.utils import cint, flt, getdate, nowdate
 
 
 def _allowed_pallet_uoms() -> list[str]:
@@ -365,6 +365,8 @@ def validate_delivery_note_pallets(doc, method=None):
                 )
             )
 
+    _validate_manifest_batches(doc, allocations)
+
     # Soft cross-check: for items that appear in the manifest, compare the
     # allocated total against the Delivery Note quantity (per item + batch).
     allocated: dict = {}
@@ -404,3 +406,70 @@ def validate_delivery_note_pallets(doc, method=None):
             indicator="orange",
             alert=True,
         )
+
+
+def _get_available_batch_qty(batch_no: str, warehouse: str, item_code: str) -> float:
+    """Current stock-UOM availability of a batch in a warehouse.
+
+    Thin seam over erpnext's get_batch_qty (imported lazily so this module
+    stays importable in plain unit tests), patched out in tests.
+    """
+    from erpnext.stock.doctype.batch.batch import get_batch_qty
+
+    return flt(get_batch_qty(batch_no=batch_no, warehouse=warehouse, item_code=item_code))
+
+
+def _validate_manifest_batches(doc, allocations) -> None:
+    """Hard guardrails on manifest batches: no expired batch, no over-allocation.
+
+    - A batch whose expiry_date lies before the posting date blocks saving.
+    - Per (item, batch, warehouse), the allocated total (converted to the
+      stock UOM via the item row's conversion factor) must not exceed the
+      batch's current availability in that warehouse. The warehouse is the
+      matching item row's, falling back to the document's source warehouse;
+      when no warehouse can be determined the availability check is skipped.
+    """
+    posting_date = getdate(doc.get("posting_date") or nowdate())
+
+    warehouse_by_item: dict = {}
+    conversion_by_item: dict = {}
+    for row in doc.get("items") or []:
+        if row.get("item_code") not in warehouse_by_item and row.get("warehouse"):
+            warehouse_by_item[row.get("item_code")] = row.get("warehouse")
+        if row.get("item_code") not in conversion_by_item:
+            conversion_by_item[row.get("item_code")] = flt(row.get("conversion_factor")) or 1.0
+
+    totals: dict = {}
+    for allocation in allocations:
+        batch_no = allocation.get("batch_no")
+        if not batch_no:
+            continue
+        item_code = allocation.get("item_code")
+        warehouse = warehouse_by_item.get(item_code) or doc.get("set_warehouse")
+        key = (item_code, batch_no, warehouse)
+        stock_qty = flt(allocation.get("qty")) * conversion_by_item.get(item_code, 1.0)
+        totals[key] = flt(totals.get(key)) + stock_qty
+
+    checked_expiry: set = set()
+    for (item_code, batch_no, warehouse), stock_qty in totals.items():
+        if batch_no not in checked_expiry:
+            checked_expiry.add(batch_no)
+            expiry = frappe.db.get_value("Batch", batch_no, "expiry_date")
+            if expiry and getdate(expiry) < posting_date:
+                frappe.throw(
+                    _(
+                        "Pallets table: Batch {0} expired on {1} and cannot be "
+                        "put on a pallet."
+                    ).format(batch_no, frappe.utils.formatdate(expiry))
+                )
+
+        if not warehouse:
+            continue
+        available = _get_available_batch_qty(batch_no, warehouse, item_code)
+        if stock_qty > available + 0.001:
+            frappe.throw(
+                _(
+                    "Pallets table: {0} of Batch {1} allocated, but only {2} "
+                    "is available in {3}."
+                ).format(flt(stock_qty, 4), batch_no, flt(available, 4), warehouse)
+            )

--- a/isnack/api/test_delivery_note_pallets.py
+++ b/isnack/api/test_delivery_note_pallets.py
@@ -378,6 +378,109 @@ class TestValidateDeliveryNotePallets(unittest.TestCase):
         mock_msgprint.assert_called_once()
 
 
+class TestManifestBatchGuardrails(unittest.TestCase):
+    """Tests for the expired-batch and batch-availability guardrails."""
+
+    @staticmethod
+    def _doc(alloc_qty=6.0, batch="AAA-005", conversion=1.0, warehouse="FG - ISN"):
+        items = [
+            _FakeRow(
+                item_code="FG10010",
+                qty=10.0,
+                batch_no=None,
+                warehouse=warehouse,
+                conversion_factor=conversion,
+                idx=1,
+            )
+        ]
+        pallets = [
+            _FakeRow(
+                pallet_no=1,
+                pallet_type="EURO 1",
+                item_code="FG10010",
+                batch_no=batch,
+                qty=alloc_qty,
+                idx=1,
+            )
+        ]
+        doc = _FakePalletDoc(items=items, pallets=pallets)
+        doc._values["posting_date"] = "2026-07-08"
+        doc._values["set_warehouse"] = None
+        return doc
+
+    @patch("isnack.api.delivery_note_pallets._get_available_batch_qty")
+    @patch("isnack.api.delivery_note_pallets.frappe.msgprint")
+    @patch("isnack.api.delivery_note_pallets.frappe.db.get_value")
+    def test_valid_batch_within_stock_passes(
+        self, mock_get_value, mock_msgprint, mock_available
+    ):
+        mock_get_value.return_value = "2026-11-30"
+        mock_available.return_value = 100.0
+        validate_delivery_note_pallets(self._doc(alloc_qty=10.0))
+        mock_available.assert_called_once_with("AAA-005", "FG - ISN", "FG10010")
+
+    @patch(
+        "isnack.api.delivery_note_pallets.frappe.throw",
+        side_effect=ValueError,
+    )
+    @patch("isnack.api.delivery_note_pallets._get_available_batch_qty")
+    @patch("isnack.api.delivery_note_pallets.frappe.db.get_value")
+    def test_expired_batch_throws(self, mock_get_value, mock_available, _throw):
+        mock_get_value.return_value = "2026-07-07"
+        mock_available.return_value = 100.0
+        with self.assertRaises(ValueError):
+            validate_delivery_note_pallets(self._doc())
+
+    @patch(
+        "isnack.api.delivery_note_pallets.frappe.throw",
+        side_effect=ValueError,
+    )
+    @patch("isnack.api.delivery_note_pallets._get_available_batch_qty")
+    @patch("isnack.api.delivery_note_pallets.frappe.msgprint")
+    @patch("isnack.api.delivery_note_pallets.frappe.db.get_value")
+    def test_over_allocation_throws(
+        self, mock_get_value, mock_msgprint, mock_available, _throw
+    ):
+        mock_get_value.return_value = None
+        mock_available.return_value = 3.0
+        with self.assertRaises(ValueError):
+            validate_delivery_note_pallets(self._doc(alloc_qty=6.0))
+
+    @patch("isnack.api.delivery_note_pallets._get_available_batch_qty")
+    @patch("isnack.api.delivery_note_pallets.frappe.msgprint")
+    @patch("isnack.api.delivery_note_pallets.frappe.db.get_value")
+    def test_conversion_factor_converts_to_stock_uom(
+        self, mock_get_value, mock_msgprint, mock_available
+    ):
+        # 6 cartons x 21 pkt/carton = 126 stock units, above 100 available.
+        mock_get_value.return_value = None
+        mock_available.return_value = 100.0
+        with patch(
+            "isnack.api.delivery_note_pallets.frappe.throw",
+            side_effect=ValueError,
+        ):
+            with self.assertRaises(ValueError):
+                validate_delivery_note_pallets(
+                    self._doc(alloc_qty=6.0, conversion=21.0)
+                )
+
+    @patch("isnack.api.delivery_note_pallets._get_available_batch_qty")
+    @patch("isnack.api.delivery_note_pallets.frappe.msgprint")
+    @patch("isnack.api.delivery_note_pallets.frappe.db.get_value")
+    def test_no_warehouse_skips_availability(
+        self, mock_get_value, mock_msgprint, mock_available
+    ):
+        mock_get_value.return_value = None
+        validate_delivery_note_pallets(self._doc(alloc_qty=10.0, warehouse=None))
+        mock_available.assert_not_called()
+
+    @patch("isnack.api.delivery_note_pallets._get_available_batch_qty")
+    @patch("isnack.api.delivery_note_pallets.frappe.msgprint")
+    def test_batchless_allocation_skips_checks(self, mock_msgprint, mock_available):
+        validate_delivery_note_pallets(self._doc(alloc_qty=10.0, batch=None))
+        mock_available.assert_not_called()
+
+
 class TestGetBundleBatches(unittest.TestCase):
     """Tests for the Serial and Batch Bundle -> batch numbers helper."""
 

--- a/isnack/public/js/delivery_note.js
+++ b/isnack/public/js/delivery_note.js
@@ -176,7 +176,22 @@ function isnack_dn_set_pallet_type_query(frm) {
             if (known.length) {
                 return { filters: { name: ["in", known] } };
             }
-            return { filters: { item: item_code } };
+            // No batches picked on the rows yet: fall back to ERPNext's
+            // standard batch search, which hides expired batches and only
+            // offers stock available in the warehouse on the posting date.
+            const item_row = (frm.doc.items || []).find(
+                (i) => i.item_code === item_code
+            );
+            return {
+                query: "erpnext.controllers.queries.get_batch_no",
+                filters: {
+                    item_code: item_code,
+                    warehouse:
+                        (item_row && item_row.warehouse) ||
+                        frm.doc.set_warehouse,
+                    posting_date: frm.doc.posting_date,
+                },
+            };
         });
     }
 }


### PR DESCRIPTION
Guardrails on the manifest's batch usage, in two layers:
- Save-time (hard): a batch whose expiry_date lies before the posting date throws; per (item, batch, warehouse) the allocated total - converted to the stock UOM via the item row's conversion factor - must not exceed the batch's availability in that warehouse (matching item row's warehouse, falling back to the source warehouse; skipped when none is set). Batch availability comes through a lazy _get_available_batch_qty seam over erpnext's get_batch_qty so the module stays unit-testable.
- Picker-side (soft): when no row batches are known for the item, the Batch picker now uses erpnext's standard get_batch_no search (warehouse + posting date aware, hides expired and zero-stock batches) instead of listing every batch of the item.